### PR TITLE
fix(build): bootstrap GhosttyKit automatically and validate artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- `mise run build`/`build:release` now auto-bootstrap GhosttyKit via `build:ghostty` to avoid missing XCFramework errors on fresh clones
+- `scripts/build-ghostty.sh` now validates XCFramework contents and rebuilds invalid artifacts instead of treating empty directories as valid
+- `scripts/build-ghostty.sh` now auto-installs the Metal Toolchain when `xcrun metal` is unavailable
+
 ## [0.1.0] - 2026-03-20
 
 Initial release of Mori — a macOS native workspace terminal organized around Projects, Worktrees, and tmux sessions.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ mise run test            # Run all tests
 mise run clean           # Clean build artifacts
 ```
 
-The libghostty XCFramework must be built first:
+`mise run build` and `mise run build:release` automatically bootstrap the libghostty XCFramework on first run. You can also build it manually:
 
 ```bash
-mise run build:ghostty   # Requires Zig 0.15.2 + Xcode
+mise run build:ghostty   # Requires Zig 0.15.2 + Xcode (downloads Metal Toolchain if missing)
 ```
 
 ## CLI

--- a/README.zh.md
+++ b/README.zh.md
@@ -61,10 +61,10 @@ mise run test            # 运行所有测试
 mise run clean           # 清理构建产物
 ```
 
-libghostty XCFramework 需要先行构建：
+`mise run build` 和 `mise run build:release` 首次运行会自动引导构建 libghostty XCFramework。你也可以手动执行：
 
 ```bash
-mise run build:ghostty   # 需要 Zig 0.15.2 + Xcode
+mise run build:ghostty   # 需要 Zig 0.15.2 + Xcode（缺少 Metal Toolchain 时会自动下载）
 ```
 
 ## CLI

--- a/mise.toml
+++ b/mise.toml
@@ -23,10 +23,12 @@ swift run Mori
 
 [tasks.build]
 description = "Debug build"
+depends = ["build:ghostty"]
 run = "swift build 2>&1 | xcbeautify"
 
 [tasks."build:release"]
 description = "Release build"
+depends = ["build:ghostty"]
 run = "swift build -c release 2>&1 | xcbeautify"
 
 [tasks.test]

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -11,6 +11,13 @@ FRAMEWORK_DIR="$PROJECT_ROOT/Frameworks"
 XCFRAMEWORK="$FRAMEWORK_DIR/GhosttyKit.xcframework"
 RESOURCES_DIR="$FRAMEWORK_DIR/ghostty-resources"
 
+has_valid_xcframework() {
+    [[ -f "$XCFRAMEWORK/Info.plist" ]] || return 1
+    local static_lib
+    static_lib="$(find "$XCFRAMEWORK" -type f -name "*.a" -print -quit 2>/dev/null || true)"
+    [[ -n "$static_lib" ]]
+}
+
 # Clean mode: remove built artifacts
 if [[ "${1:-}" == "--clean" ]]; then
     echo "Cleaning Ghostty build artifacts..."
@@ -24,10 +31,15 @@ if [[ ! -f "$GHOSTTY_DIR/build.zig" ]]; then
 fi
 
 # Skip if already built
-if [[ -d "$XCFRAMEWORK" && -d "$RESOURCES_DIR" ]]; then
+if has_valid_xcframework && [[ -d "$RESOURCES_DIR" ]]; then
     echo "GhosttyKit.xcframework and resources already exist at $FRAMEWORK_DIR"
     echo "Run with --clean to rebuild."
     exit 0
+fi
+
+if [[ -d "$XCFRAMEWORK" ]] && ! has_valid_xcframework; then
+    echo "Found invalid GhosttyKit.xcframework at $XCFRAMEWORK; rebuilding..."
+    rm -rf "$XCFRAMEWORK"
 fi
 
 # Verify zig is available
@@ -41,11 +53,23 @@ echo "Using Zig $ZIG_VERSION"
 
 cd "$GHOSTTY_DIR"
 
+if ! xcrun -sdk macosx --find metal >/dev/null 2>&1; then
+    echo "Metal toolchain not found. Installing with xcodebuild..."
+    xcodebuild -downloadComponent MetalToolchain
+fi
+
 # Patch: skip iOS/iOS Simulator builds when using native target.
 # Ghostty's GhosttyXCFramework.zig eagerly initializes iOS targets even
 # when xcframework-target=native. This fails without Xcode.app (needs iphoneos SDK).
 # The patch moves iOS init inside the universal branch only.
 XCFW_ZIG="$GHOSTTY_DIR/src/build/GhosttyXCFramework.zig"
+restore_native_patch() {
+    if grep -q "MORI_PATCHED" "$XCFW_ZIG" 2>/dev/null; then
+        git -C "$GHOSTTY_DIR" checkout -- src/build/GhosttyXCFramework.zig >/dev/null 2>&1 || true
+    fi
+}
+trap restore_native_patch EXIT
+
 if ! grep -q "MORI_PATCHED" "$XCFW_ZIG" 2>/dev/null; then
     echo "Applying native-only build patch..."
     cat > "$XCFW_ZIG" << 'ZIGEOF'


### PR DESCRIPTION
## Summary
- make `mise run build` and `mise run build:release` depend on `build:ghostty` so fresh clones bootstrap GhosttyKit automatically
- harden `scripts/build-ghostty.sh` to detect invalid/empty `GhosttyKit.xcframework` and rebuild instead of false-positive skipping
- auto-install Metal Toolchain in `build-ghostty` when `xcrun metal` is unavailable
- restore patched Ghostty build file on exit so `vendor/ghostty` stays clean
- update README (EN/ZH) and CHANGELOG to match the new build behavior

## Validation
- `bash scripts/build-ghostty.sh --clean`
- `mise run build`
