### PR TITLE
fix(tmux): apply theme to newly created sessions

### DIFF
--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -196,6 +196,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let tmuxBackend = self?.workspaceManager?.tmuxBackend else { return }
             let model = ProxySettingsApplicator.load()
             await ProxySettingsApplicator.apply(model, tmuxBackend: tmuxBackend)
+
+            // Apply theme (including status bar off) to the newly created session
+            if let terminalArea = self?.terminalAreaController {
+                await TmuxThemeApplicator.apply(
+                    themeInfo: terminalArea.themeInfo,
+                    tmuxBackend: tmuxBackend
+                )
+            }
         }
 
         // Restore previously saved UI state (project, worktree, window selection)


### PR DESCRIPTION
## Problem

The tmux status bar was visible on sessions created after app startup. The `TmuxThemeApplicator` (which sets `status off`, pane border colors, etc.) was only applied at startup and on theme changes — new sessions inherited the default tmux config.

## Fix

Apply theme settings in the `onSessionCreated` callback so every new tmux session immediately gets the correct theme, including `status=off`.

## Changes

- `AppDelegate.swift`: Call `TmuxThemeApplicator.apply()` in the `onSessionCreated` closure after applying proxy settings.