### PR TITLE
feat: code signing and notarization support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,34 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
 
-      - name: Bundle unsigned Mori.app
+      - name: Import signing certificate
+        if: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+      - name: Bundle Mori.app
+        env:
+          SIGNING_IDENTITY: ${{ secrets.APPLE_CERTIFICATE_P12 != '' && format('Developer ID Application: {0} ({1})', secrets.APPLE_DEVELOPER_NAME, secrets.APPLE_TEAM_ID) || '' }}
         run: bash scripts/bundle.sh
 
       - name: Upload Mori.app
@@ -85,3 +112,9 @@ jobs:
           name: Mori.app
           path: Mori.app
           retention-days: 30
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     needs: ghosttykit
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -41,15 +41,56 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
 
-      - name: Build and bundle unsigned Mori.app
-        run: bash scripts/bundle.sh
-
       - name: Run tests
         run: |
           cd Packages/MoriCore && swift run MoriCoreTests && cd ../..
           cd Packages/MoriPersistence && swift run MoriPersistenceTests && cd ../..
           cd Packages/MoriTmux && swift run MoriTmuxTests && cd ../..
           cd Packages/MoriIPC && swift run MoriIPCTests && cd ../..
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create temporary keychain
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+
+          # Allow codesign to access keychain
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+      - name: Store notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          xcrun notarytool store-credentials "mori-notarize" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD"
+
+      - name: Build, sign, and notarize Mori.app
+        env:
+          SIGNING_IDENTITY: "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_NAME }} (${{ secrets.APPLE_TEAM_ID }})"
+          KEYCHAIN_PROFILE: "mori-notarize"
+        run: bash scripts/bundle.sh
 
       - name: Create release archive
         run: |
@@ -63,3 +104,9 @@ jobs:
         with:
           files: ${{ env.RELEASE_ASSET }}
           generate_release_notes: true
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true

--- a/Mori.entitlements
+++ b/Mori.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,323 @@
+# Code Signing & Notarization
+
+This guide covers everything needed to sign and notarize Mori for macOS distribution outside the App Store.
+
+## Prerequisites
+
+- **Apple Developer Program** membership ($99/year) — [developer.apple.com/programs](https://developer.apple.com/programs)
+  - Free accounts do NOT have access to Developer ID certificates
+- **Xcode** installed (for command-line tools)
+- **macOS Keychain Access** (built-in)
+
+## 1. Create a Developer ID Application Certificate
+
+This certificate is required to sign apps for distribution outside the Mac App Store.
+
+### 1.1 Generate a Certificate Signing Request (CSR)
+
+The CSR creates a **private key** on your machine and a request file to send to Apple. The private key never leaves your machine — Apple uses the CSR to issue a certificate that pairs with it.
+
+> **Critical**: You MUST generate the CSR on the same machine where you will sign apps. The private key is stored in your macOS Keychain during CSR generation. If you install a certificate on a machine that doesn't have the matching private key, `security find-identity` will not show it as a valid codesigning identity.
+
+1. Open **Keychain Access** (Applications > Utilities > Keychain Access)
+2. Menu bar: **Keychain Access** > **Certificate Assistant** > **Request a Certificate From a Certificate Authority...**
+3. Fill in the dialog:
+   - **User Email Address**: your Apple ID email (e.g. `you@example.com`)
+   - **Common Name**: your full name (e.g. "Wei Liu") — this appears in the certificate
+   - **CA Email Address**: leave blank
+   - **Request is**: select **Saved to disk**
+4. Click **Continue** and save the `.certSigningRequest` file somewhere you can find it (e.g. Desktop)
+
+What happens behind the scenes:
+- A 2048-bit RSA key pair is generated
+- The **private key** is stored in your **login** keychain (Keychain Access > login > Keys — look for a key matching your Common Name)
+- The **public key** is embedded in the `.certSigningRequest` file
+
+### 1.2 Create the Certificate on Apple Developer Portal
+
+1. Go to [developer.apple.com/account/resources/certificates/add](https://developer.apple.com/account/resources/certificates/add)
+2. Under **Software**, select **Developer ID Application**
+   - This option is only available with a paid Apple Developer Program membership
+   - Do NOT select "Apple Development" or "Apple Distribution" — those are for App Store only
+3. Click **Continue**
+4. If prompted to select a **Developer ID Certificate Authority**, choose **Developer ID - G2 (Expiring 09/17/2031)** (the newer one)
+5. Click **Choose File** and upload the `.certSigningRequest` file from step 1.1
+6. Click **Continue**
+7. Click **Download** to get the `.cer` file
+
+### 1.3 Install the Certificate
+
+1. Double-click the downloaded `.cer` file — it opens in Keychain Access automatically
+2. It installs to your **login** keychain and pairs with the private key from step 1.1
+3. Verify it's installed and paired correctly:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+You should see output like:
+
+```
+1) ABCDEF1234... "Developer ID Application: Wei Liu (ABC1234DEF)"
+     1 valid identities found
+```
+
+The full string in quotes is your **`SIGNING_IDENTITY`**. The 10-character code in parentheses is your **Team ID**.
+
+4. In **Keychain Access**, expand the certificate (click the triangle) — you should see a **private key** nested under it. If there's no private key, see troubleshooting below.
+
+### 1.4 Troubleshooting: Certificate Not Showing Up
+
+**Symptom**: You installed the `.cer` but `security find-identity -v -p codesigning` doesn't list "Developer ID Application".
+
+**Cause**: The certificate can't find its matching private key. This happens when:
+- The CSR was generated on a **different machine**
+- The private key was **deleted** from the keychain
+- The certificate was installed in a **different keychain** (e.g. System instead of login)
+
+**Fix**:
+
+```bash
+# Check if the cert is installed at all (even without valid signing)
+security find-identity -v
+
+# Check a specific keychain
+security find-identity -v -p codesigning ~/Library/Keychains/login.keychain-db
+```
+
+Open **Keychain Access** > **login** keychain > **Certificates** tab > find the Developer ID certificate > expand it. If no private key is shown, you need to start over:
+
+1. **Revoke** the certificate at [developer.apple.com/account/resources/certificates/list](https://developer.apple.com/account/resources/certificates/list)
+2. Generate a **new CSR** on this machine (step 1.1)
+3. Create a **new** Developer ID Application certificate with the new CSR (step 1.2)
+4. Install the new `.cer` (step 1.3)
+
+### 1.5 Back Up Your Certificate + Private Key
+
+If you lose the private key, you'll need to revoke and recreate the certificate. Export a backup:
+
+1. Open **Keychain Access** > **login** keychain > **Certificates**
+2. Right-click your "Developer ID Application" certificate > **Export...**
+3. Choose format **Personal Information Exchange (.p12)**
+4. Set a strong password
+5. Store the `.p12` file securely (e.g. password manager, encrypted drive)
+
+To restore on another machine or after a reinstall, double-click the `.p12` file and enter the password — it imports both the certificate and private key.
+
+> **Note**: "Apple Development" and "Apple Distribution" certificates (available in Xcode) are for App Store distribution and development. They will NOT work for distributing outside the App Store.
+
+## 2. Create an App-Specific Password
+
+Apple requires an app-specific password for notarization (your regular Apple ID password won't work).
+
+1. Go to [account.apple.com](https://account.apple.com)
+2. Sign in with your Apple ID
+3. Navigate to **Sign-In and Security** > **App-Specific Passwords**
+4. Click **Generate an app-specific password** (or the **+** button)
+5. Enter a label, e.g. `mori-notarize`
+6. Copy the generated password (format: `xxxx-xxxx-xxxx-xxxx`)
+
+> **Important**: Save this password somewhere secure. You can only see it once.
+
+## 3. Find Your Team ID
+
+Your Team ID is the 10-character alphanumeric identifier for your Apple Developer account.
+
+### Option A: From the certificate
+
+```bash
+security find-identity -v -p codesigning | grep "Developer ID"
+```
+
+The Team ID is in parentheses: `Developer ID Application: Your Name (TEAM_ID_HERE)`
+
+### Option B: From the developer portal
+
+Go to [developer.apple.com/account](https://developer.apple.com/account) > **Membership details** > **Team ID**
+
+## 4. Store Notarization Credentials
+
+Store your credentials in the macOS Keychain so they don't need to be entered repeatedly:
+
+```bash
+xcrun notarytool store-credentials "mori-notarize" \
+  --apple-id "your-apple-id@email.com" \
+  --team-id "ABC1234DEF" \
+  --password "xxxx-xxxx-xxxx-xxxx"
+```
+
+Replace:
+- `your-apple-id@email.com` — your Apple ID email
+- `ABC1234DEF` — your Team ID from step 3
+- `xxxx-xxxx-xxxx-xxxx` — your app-specific password from step 2
+
+Verify the credentials work:
+
+```bash
+xcrun notarytool history --keychain-profile "mori-notarize"
+```
+
+This should return without errors (empty history is fine).
+
+## 5. Sign and Notarize Locally
+
+### Quick build (signed + notarized)
+
+```bash
+SIGNING_IDENTITY="Developer ID Application: Your Name (ABC1234DEF)" \
+KEYCHAIN_PROFILE="mori-notarize" \
+mise run bundle
+```
+
+### Quick build (signed only, no notarization)
+
+```bash
+SIGNING_IDENTITY="Developer ID Application: Your Name (ABC1234DEF)" \
+mise run bundle
+```
+
+### Quick build (unsigned, for local development)
+
+```bash
+mise run bundle
+```
+
+### Manual signing (if you already have a built .app)
+
+```bash
+# Sign only
+SIGNING_IDENTITY="Developer ID Application: Your Name (ABC1234DEF)" \
+bash scripts/sign.sh
+
+# Sign + notarize
+SIGNING_IDENTITY="Developer ID Application: Your Name (ABC1234DEF)" \
+KEYCHAIN_PROFILE="mori-notarize" \
+bash scripts/sign.sh --notarize
+```
+
+### Verify the result
+
+```bash
+# Check code signature
+codesign --verify --deep --strict --verbose=2 Mori.app
+
+# Check notarization staple
+stapler validate Mori.app
+
+# Check Gatekeeper acceptance
+spctl --assess --type execute --verbose=2 Mori.app
+```
+
+## 6. GitHub Actions (CI/CD)
+
+The release workflow automatically signs and notarizes when the required secrets are configured.
+
+### 6.1 Export Your Certificate as .p12
+
+1. Open **Keychain Access**
+2. Find your "Developer ID Application" certificate in the **login** keychain
+3. Right-click the certificate > **Export...**
+4. Choose **Personal Information Exchange (.p12)** format
+5. Set a strong password and save the file
+
+### 6.2 Base64-Encode the .p12
+
+```bash
+base64 -i certificate.p12 | pbcopy
+```
+
+This copies the base64 string to your clipboard.
+
+### 6.3 Add GitHub Repository Secrets
+
+Go to your repo on GitHub > **Settings** > **Secrets and variables** > **Actions** > **New repository secret**
+
+Add each of these secrets:
+
+| Secret Name | Value | Example |
+|---|---|---|
+| `APPLE_CERTIFICATE_P12` | Base64-encoded .p12 from step 6.2 | `MIIKYwIBAzCCCi...` |
+| `APPLE_CERTIFICATE_PASSWORD` | The password you set when exporting .p12 | `your-p12-password` |
+| `APPLE_DEVELOPER_NAME` | Your name exactly as it appears in the certificate | `Wei Liu` |
+| `APPLE_TEAM_ID` | Your 10-character Team ID | `ABC1234DEF` |
+| `APPLE_ID` | Your Apple ID email | `you@example.com` |
+| `APPLE_APP_PASSWORD` | App-specific password from step 2 | `xxxx-xxxx-xxxx-xxxx` |
+
+### 6.4 How It Works
+
+When a release tag (`v*`) is pushed:
+
+1. **Certificate import**: The .p12 is decoded and imported into a temporary keychain on the runner
+2. **Credentials stored**: `notarytool store-credentials` saves auth to the runner's keychain
+3. **Build + sign**: `bundle.sh` builds the app and calls `sign.sh` to sign with hardened runtime
+4. **Notarize**: The signed app is submitted to Apple's notary service (waits for approval)
+5. **Staple**: The notarization ticket is stapled to the app bundle
+6. **Archive**: The signed, notarized app is zipped and attached to the GitHub Release
+7. **Cleanup**: The temporary keychain is deleted
+
+## 7. Entitlements
+
+The `Mori.entitlements` file grants the following permissions:
+
+| Entitlement | Why |
+|---|---|
+| `com.apple.security.automation.apple-events` | Send Apple Events (automation, scripting) |
+| `com.apple.security.cs.allow-unsigned-executable-memory` | Required by libghostty (Zig/Metal GPU rendering) |
+| `com.apple.security.cs.disable-library-validation` | Load the GhosttyKit framework |
+
+The app does **not** use App Sandbox (`com.apple.security.app-sandbox` is absent) because Mori requires full access to the filesystem, tmux, and shell processes.
+
+## 8. Troubleshooting
+
+### "Developer ID Application" not available in Xcode
+
+This certificate type can only be created through the [Apple Developer web portal](https://developer.apple.com/account/resources/certificates/add), not through Xcode's UI.
+
+### `errSecInternalComponent` during signing
+
+The keychain is locked or the certificate's private key is not accessible:
+
+```bash
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+```
+
+### Notarization fails with "Invalid signature"
+
+Ensure you're using `--options runtime` (hardened runtime). The `sign.sh` script does this automatically. If you signed manually, re-sign:
+
+```bash
+codesign --force --options runtime --timestamp \
+  --entitlements Mori.entitlements \
+  --sign "Developer ID Application: Your Name (ABC1234DEF)" \
+  Mori.app
+```
+
+### Notarization fails with "The software is not signed with a valid Developer ID certificate"
+
+Your certificate might be:
+- Expired — check at [developer.apple.com/account/resources/certificates/list](https://developer.apple.com/account/resources/certificates/list)
+- Revoked — create a new one following step 1
+- Not a "Developer ID Application" cert — "Apple Development" or "Apple Distribution" won't work
+
+### `spctl --assess` says "rejected"
+
+The app isn't notarized or the staple is missing:
+
+```bash
+# Check if notarized
+xcrun stapler validate Mori.app
+
+# If not, re-notarize
+SIGNING_IDENTITY="..." KEYCHAIN_PROFILE="mori-notarize" bash scripts/sign.sh --notarize
+```
+
+### Notarization takes too long
+
+Apple's notary service usually responds within 5 minutes but can take up to an hour during peak times. The `--wait` flag in `sign.sh` polls automatically.
+
+Check status of past submissions:
+
+```bash
+xcrun notarytool history --keychain-profile "mori-notarize"
+xcrun notarytool log <submission-id> --keychain-profile "mori-notarize"
+```

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -69,6 +69,15 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << EOF
 </plist>
 EOF
 
+# Sign if SIGNING_IDENTITY is set
+if [[ -n "${SIGNING_IDENTITY:-}" ]]; then
+    SIGN_ARGS=()
+    if [[ -n "${KEYCHAIN_PROFILE:-}" ]]; then
+        SIGN_ARGS+=(--notarize)
+    fi
+    bash scripts/sign.sh "${SIGN_ARGS[@]}"
+fi
+
 # In CI, keep the bundle in the working directory for archiving
 if [[ -z "${CI:-}" ]]; then
     # Quit the app if it's running

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Sign and optionally notarize Mori.app
+# Usage:
+#   scripts/sign.sh [--notarize]
+#
+# Environment variables:
+#   SIGNING_IDENTITY   — Developer ID Application identity (required)
+#   ENTITLEMENTS       — Path to entitlements file (default: Mori.entitlements)
+#   KEYCHAIN_PROFILE   — notarytool keychain profile name (required for --notarize)
+#   APP_BUNDLE         — Path to .app bundle (default: Mori.app)
+set -euo pipefail
+
+NOTARIZE=false
+for arg in "$@"; do
+    case "$arg" in
+        --notarize) NOTARIZE=true ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+APP_BUNDLE="${APP_BUNDLE:-Mori.app}"
+ENTITLEMENTS="${ENTITLEMENTS:-Mori.entitlements}"
+
+if [[ -z "${SIGNING_IDENTITY:-}" ]]; then
+    echo "❌ SIGNING_IDENTITY is not set"
+    echo "   Set it to your Developer ID Application identity, e.g.:"
+    echo "   export SIGNING_IDENTITY=\"Developer ID Application: Your Name (TEAM_ID)\""
+    exit 1
+fi
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "❌ $APP_BUNDLE not found. Run 'mise run bundle' first."
+    exit 1
+fi
+
+if [[ ! -f "$ENTITLEMENTS" ]]; then
+    echo "❌ Entitlements file not found: $ENTITLEMENTS"
+    exit 1
+fi
+
+echo "🔏 Signing $APP_BUNDLE with identity: $SIGNING_IDENTITY"
+
+# Sign embedded frameworks and dylibs first (inside-out signing)
+if [[ -d "$APP_BUNDLE/Contents/Frameworks" ]]; then
+    find "$APP_BUNDLE/Contents/Frameworks" \( -name "*.dylib" -o -name "*.framework" \) -print0 | while IFS= read -r -d '' item; do
+        echo "   Signing: $(basename "$item")"
+        codesign --force --options runtime --timestamp \
+            --sign "$SIGNING_IDENTITY" \
+            "$item"
+    done
+fi
+
+# Sign helper executables if any
+if [[ -d "$APP_BUNDLE/Contents/MacOS" ]]; then
+    find "$APP_BUNDLE/Contents/MacOS" -type f -perm +111 ! -name "Mori" -print0 | while IFS= read -r -d '' item; do
+        echo "   Signing helper: $(basename "$item")"
+        codesign --force --options runtime --timestamp \
+            --sign "$SIGNING_IDENTITY" \
+            "$item"
+    done
+fi
+
+# Sign the main app bundle
+codesign --force --options runtime --timestamp \
+    --entitlements "$ENTITLEMENTS" \
+    --sign "$SIGNING_IDENTITY" \
+    "$APP_BUNDLE"
+
+echo "✅ Signed successfully"
+
+# Verify signature
+echo "🔍 Verifying signature..."
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+echo "✅ Signature verified"
+
+# Notarize if requested
+if [[ "$NOTARIZE" == "true" ]]; then
+    if [[ -z "${KEYCHAIN_PROFILE:-}" ]]; then
+        echo "❌ KEYCHAIN_PROFILE is not set (required for notarization)"
+        echo "   Store credentials first:"
+        echo "   xcrun notarytool store-credentials \"mori-notarize\" \\"
+        echo "     --apple-id \"your@email.com\" \\"
+        echo "     --team-id \"TEAM_ID\" \\"
+        echo "     --password \"app-specific-password\""
+        exit 1
+    fi
+
+    echo "📦 Creating zip for notarization..."
+    NOTARIZE_ZIP="${APP_BUNDLE%.app}-notarize.zip"
+    ditto -c -k --keepParent "$APP_BUNDLE" "$NOTARIZE_ZIP"
+
+    echo "🚀 Submitting for notarization..."
+    xcrun notarytool submit "$NOTARIZE_ZIP" \
+        --keychain-profile "$KEYCHAIN_PROFILE" \
+        --wait
+
+    echo "📌 Stapling notarization ticket..."
+    xcrun stapler staple "$APP_BUNDLE"
+
+    # Clean up
+    rm -f "$NOTARIZE_ZIP"
+
+    echo "✅ Notarization complete"
+fi


### PR DESCRIPTION
## Summary
- Add `Mori.entitlements` for hardened runtime (apple events, unsigned executable memory for libghostty, disable library validation)
- Add `scripts/sign.sh` — standalone signing + notarization script, reusable locally and in CI
- Update `scripts/bundle.sh` to auto-sign when `SIGNING_IDENTITY` is set, auto-notarize when `KEYCHAIN_PROFILE` is also set
- Update `release.yml` — imports cert from secrets, stores notarization creds, signs + notarizes, cleans up keychain
- Update `ci.yml` — signs when secrets are available, gracefully skips if not configured
- Add `docs/code-signing.md` — full guide covering certificate creation, CSR, notarization setup, CI secrets, and troubleshooting

## Required GitHub Secrets
| Secret | Value |
|--------|-------|
| `APPLE_CERTIFICATE_P12` | Base64-encoded .p12 of Developer ID cert |
| `APPLE_CERTIFICATE_PASSWORD` | Password for the .p12 |
| `APPLE_DEVELOPER_NAME` | Name as it appears in the certificate |
| `APPLE_TEAM_ID` | 10-char team ID |
| `APPLE_ID` | Apple ID email |
| `APPLE_APP_PASSWORD` | App-specific password |

## Test plan
- [ ] Generate Developer ID Application certificate and verify `security find-identity` shows it
- [ ] Run local signed build: `SIGNING_IDENTITY="..." mise run bundle`
- [ ] Run local signed + notarized build: `SIGNING_IDENTITY="..." KEYCHAIN_PROFILE="mori-notarize" mise run bundle`
- [ ] Verify with `codesign --verify --deep --strict Mori.app`
- [ ] Verify with `spctl --assess --type execute Mori.app`
- [ ] Configure GitHub secrets and test release workflow with a tag push