### PR TITLE
🐛 fix: handle stale mori CLI IPC sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- Mori app termination now removes the IPC socket synchronously, and the `mori` CLI now reports missing or stale app sockets directly instead of timing out
+
 ## [0.1.2] - 2026-03-27
 
 ### ✨ Features

--- a/Packages/MoriIPC/Sources/MoriIPC/IPCServer.swift
+++ b/Packages/MoriIPC/Sources/MoriIPC/IPCServer.swift
@@ -32,6 +32,14 @@ public actor IPCServer {
         self.handler = handler
     }
 
+    /// Remove the Unix domain socket file synchronously.
+    /// Useful during app termination, where async actor cleanup may not finish
+    /// before the process exits.
+    public static func removeSocketFile(at path: String? = nil) {
+        let socketPath = path ?? Self.defaultSocketPath
+        try? FileManager.default.removeItem(atPath: socketPath)
+    }
+
     /// Start listening for connections.
     public func start() throws {
         // Ensure parent directory exists
@@ -184,6 +192,6 @@ public actor IPCServer {
     // MARK: - Helpers
 
     private nonisolated func removeSocketFile() {
-        try? FileManager.default.removeItem(atPath: socketPath)
+        Self.removeSocketFile(at: socketPath)
     }
 }

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -265,6 +265,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         // Stop IPC server
+        IPCServer.removeSocketFile()
         if let server = ipcServer {
             Task { await server.stop() }
         }

--- a/Sources/MoriCLI/MoriCLI.swift
+++ b/Sources/MoriCLI/MoriCLI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 import MoriIPC
 
@@ -23,6 +24,19 @@ struct MoriCLI: ParsableCommand {
 
 /// Send an IPC request and print the result as JSON.
 func runIPCRequest(_ command: IPCCommand) throws {
+    switch diagnoseIPCSocket(at: IPCServer.defaultSocketPath) {
+    case .missing:
+        let message = String.localized("Mori app is not running. Launch Mori and try again.")
+        FileHandle.standardError.write(Data(String.localized("Error: \(message)").utf8))
+        throw ExitCode.failure
+    case .stale:
+        let message = String.localized("Mori app is not accepting CLI connections. Quit and relaunch Mori, then try again.")
+        FileHandle.standardError.write(Data(String.localized("Error: \(message)").utf8))
+        throw ExitCode.failure
+    case .ready, .indeterminate:
+        break
+    }
+
     let client = IPCClient()
     let request = IPCRequest(command: command, requestId: UUID().uuidString)
     let envelope = try client.sendSync(request)
@@ -38,6 +52,61 @@ func runIPCRequest(_ command: IPCCommand) throws {
         let errorMessage = String.localized("Error: \(message)")
         FileHandle.standardError.write(Data(errorMessage.utf8))
         throw ExitCode.failure
+    }
+}
+
+private enum IPCSocketStatus {
+    case ready
+    case missing
+    case stale
+    case indeterminate
+}
+
+private func diagnoseIPCSocket(at path: String) -> IPCSocketStatus {
+    guard FileManager.default.fileExists(atPath: path) else {
+        return .missing
+    }
+
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+        return .indeterminate
+    }
+    defer { close(fd) }
+
+    var address = sockaddr_un()
+    address.sun_len = UInt8(MemoryLayout<sockaddr_un>.stride)
+    address.sun_family = sa_family_t(AF_UNIX)
+
+    let maxPathLength = MemoryLayout.size(ofValue: address.sun_path)
+    let pathBytes = Array(path.utf8)
+    guard pathBytes.count < maxPathLength else {
+        return .indeterminate
+    }
+
+    withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+        buffer.initializeMemory(as: UInt8.self, repeating: 0)
+        _ = pathBytes.withUnsafeBytes { src in
+            memcpy(buffer.baseAddress, src.baseAddress, src.count)
+        }
+    }
+
+    let didConnect = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+            connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.stride))
+        }
+    }
+
+    if didConnect == 0 {
+        return .ready
+    }
+
+    switch errno {
+    case ENOENT:
+        return .missing
+    case ECONNREFUSED:
+        return .stale
+    default:
+        return .indeterminate
     }
 }
 

--- a/Sources/MoriCLI/Resources/en.lproj/Localizable.strings
+++ b/Sources/MoriCLI/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,8 @@
 "Focus a project and worktree" = "Focus a project and worktree";
 "Keys to send" = "Keys to send";
 "List all projects" = "List all projects";
+"Mori app is not accepting CLI connections. Quit and relaunch Mori, then try again." = "Mori app is not accepting CLI connections. Quit and relaunch Mori, then try again.";
+"Mori app is not running. Launch Mori and try again." = "Mori app is not running. Launch Mori and try again.";
 "Mori workspace CLI — communicate with the running Mori app." = "Mori workspace CLI — communicate with the running Mori app.";
 "Open a project from a path" = "Open a project from a path";
 "Path to project directory" = "Path to project directory";

--- a/Sources/MoriCLI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/MoriCLI/Resources/zh-Hans.lproj/Localizable.strings
@@ -5,6 +5,8 @@
 "Focus a project and worktree" = "聚焦到项目和工作树";
 "Keys to send" = "要发送的按键";
 "List all projects" = "列出所有项目";
+"Mori app is not accepting CLI connections. Quit and relaunch Mori, then try again." = "Mori 应用当前未接受 CLI 连接。请退出并重新启动 Mori 后重试。";
+"Mori app is not running. Launch Mori and try again." = "Mori 应用未运行。请先启动 Mori 后重试。";
 "Mori workspace CLI — communicate with the running Mori app." = "Mori 工作区 CLI — 与运行中的 Mori 应用通信。";
 "Open a project from a path" = "从路径打开项目";
 "Path to project directory" = "项目目录路径";


### PR DESCRIPTION
## Summary
- remove the IPC socket synchronously during app termination so the CLI is less likely to hit a stale socket
- detect missing and stale IPC sockets in the CLI before sending the request, with localized error messages
- document the fix in the changelog

## Verification
- swift build
- mise run test:ipc
- swift run mori project list
- verified the CLI reports a stale-socket error instead of timing out when no server is listening