### PR TITLE
✨ fix: enhance GhosttySettingsView with content shape for better touch targets

### DIFF
--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -238,6 +238,7 @@ public struct GhosttySettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .padding(.bottom, 8)
@@ -262,6 +263,7 @@ public struct GhosttySettingsView: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
+            .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: 6)
                     .fill(isSelected ? Color.accentColor : .clear)


### PR DESCRIPTION
Added better touch targets for settings sidepanel

<img width="189" height="587" alt="image" src="https://github.com/user-attachments/assets/74d69a5a-110b-4c92-9697-2b884d3aacf1" />
