### PR TITLE
Fix: slugify project shortName in tmux session naming

### DIFF
--- a/Packages/MoriTmux/Sources/MoriTmux/SessionNaming.swift
+++ b/Packages/MoriTmux/Sources/MoriTmux/SessionNaming.swift
@@ -49,9 +49,11 @@ public enum SessionNaming {
 
     /// Build a Mori session name from project short name and branch name.
     /// Format: `<shortName>/<branchSlug>` (e.g. `mori/main`, `api/auth-flow`).
+    /// Both parts are slugified to ensure tmux compatibility (no dots, colons, etc.).
     public static func sessionName(projectShortName: String, worktree: String) -> String {
         let branch = stripBranchPrefix(worktree)
-        return "\(projectShortName)\(separator)\(slugify(branch))"
+        let project = slugify(projectShortName)
+        return "\(project.isEmpty ? "project" : project)\(separator)\(slugify(branch))"
     }
 
     /// Check if a session name matches the Mori naming convention (contains `/`).

--- a/Packages/MoriTmux/Tests/MoriTmuxTests/main.swift
+++ b/Packages/MoriTmux/Tests/MoriTmuxTests/main.swift
@@ -205,6 +205,19 @@ func testSessionNameGeneration() {
     )
 }
 
+func testSessionNameSanitizesDotPrefix() {
+    // Directories starting with "." (e.g. ~/.claude) must have the dot stripped
+    // because tmux does not allow "." in session names.
+    assertEqual(
+        SessionNaming.sessionName(projectShortName: ".claude", worktree: "main"),
+        "claude/main"
+    )
+    assertEqual(
+        SessionNaming.sessionName(projectShortName: "vue.js", worktree: "main"),
+        "vue-js/main"
+    )
+}
+
 func testStripBranchPrefix() {
     assertEqual(SessionNaming.stripBranchPrefix("feature/auth"), "auth")
     assertEqual(SessionNaming.stripBranchPrefix("feat/sidebar"), "sidebar")
@@ -564,6 +577,7 @@ testSlugifySimple()
 testSlugifySpecialChars()
 testSlugifyUnicode()
 testSessionNameGeneration()
+testSessionNameSanitizesDotPrefix()
 testStripBranchPrefix()
 testSessionNameParsing()
 testSessionNameParsingComplex()


### PR DESCRIPTION
## Summary

- Directories starting with `.` (e.g. `~/.claude`) produce a shortName like `.claude`, which gets passed directly into the tmux session name as `.claude/main`
- tmux does not allow `.` in session names (`.` is used in the `session:window.pane` target syntax), causing session creation output to be unparseable → "Failed to parse created session" error
- Apply `slugify()` to the `projectShortName` part in `SessionNaming.sessionName()`, so `.claude` → `claude/main`, `vue.js` → `vue-js/main`

## Test plan

- [x] All 202 existing MoriTmux assertions pass
- [x] New test `testSessionNameSanitizesDotPrefix` covers `.claude` and `vue.js` cases
- [ ] Manual: add `~/.claude` (or any dot-prefixed directory) as a workspace → should create tmux session without error