### PR TITLE
docs: 添加 GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,117 @@
+name: Bug Report
+description: Report a reproducible problem in Mori
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please fill in the details below so we can reproduce it without a long back-and-forth.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true
+        - label: I can reproduce this on the latest Mori release, or I included the commit/version I tested
+          required: true
+  - type: input
+    id: mori-version
+    attributes:
+      label: Mori version
+      description: Release version or commit SHA
+      placeholder: "0.3.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install Mori?
+      options:
+        - Homebrew
+        - GitHub release (.dmg or .zip)
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: What area is affected?
+      multiple: true
+      options:
+        - macOS app UI
+        - Terminal rendering
+        - tmux sessions or panes
+        - Git projects or worktrees
+        - SSH remote projects
+        - Command palette or keyboard shortcuts
+        - CLI
+        - MoriRemote iOS app
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: "macOS 15.4"
+    validations:
+      required: true
+  - type: input
+    id: tmux-version
+    attributes:
+      label: tmux version
+      description: Run `tmux -V`
+      placeholder: "tmux 3.5a"
+    validations:
+      required: false
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior, error, or broken flow.
+      placeholder: |
+        Example:
+        After creating a worktree from the sidebar, Mori opens the session,
+        but the pane stays blank and never attaches to tmux.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open Mori
+        2. Add or select project `...`
+        3. Run / click `...`
+        4. Observe `...`
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What did you expect to happen?
+      placeholder: Mori should attach to the new tmux session and show the shell prompt.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs, screenshots, or recordings
+      description: Paste logs here and drag screenshots or videos into the issue after the form opens.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Anything else?
+      description: Extra context, related issues, unusual setup, or a workaround you found.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,80 @@
+name: Feature Request
+description: Suggest an improvement for Mori
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea.
+
+        Keep this focused on the user problem and the simplest useful outcome.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find the same request
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: What area would this improve?
+      multiple: true
+      options:
+        - macOS app
+        - Terminal or tmux workflow
+        - Git projects or worktrees
+        - SSH remote projects
+        - CLI
+        - MoriRemote iOS app
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Start with the pain point, not the implementation.
+      placeholder: |
+        Example:
+        When switching between several worktrees, it is hard to tell which ones
+        still have running agents or background tasks that need attention.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like Mori to do?
+      placeholder: |
+        Example:
+        Add a compact status indicator in the sidebar row so I can see agent or
+        task state without opening each worktree.
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: Why is this useful?
+      description: Tell us what gets faster, easier, or less error-prone.
+      placeholder: |
+        Example:
+        This would make multi-worktree navigation much faster and reduce context switching.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What alternatives have you tried?
+      description: Existing workflow, workaround, plugin, script, or why there is no good workaround.
+    validations:
+      required: false
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Additional context
+      description: Mockups, references, related issues, or examples from other tools.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 📝 Documentation
+
+- Add practical GitHub issue templates for bug reports and feature requests
+
 ## [0.3.0] - 2026-04-02
 
 ### ✨ Features


### PR DESCRIPTION
## 摘要

- 新增 GitHub Issue Form：`Bug Report`，收集版本、安装方式、macOS / tmux 环境、影响范围、复现步骤、期望结果和日志，减少来回追问
- 新增 GitHub Issue Form：`Feature Request`，聚焦用户痛点、提议内容、价值和替代方案，方便维护者判断优先级
- 新增 `.github/ISSUE_TEMPLATE/config.yml`，关闭空白 issue，统一入口到结构化模板
- 更新 `CHANGELOG.md` 的 `Unreleased` 记录

## 设计取舍

- 保持最小集合，只放 `Bug Report` 和 `Feature Request` 两类常用模板
- 不额外加入 `question` / `support` 模板，也不加 `contact_links`，避免把 issue tracker 变成杂项入口
- 字段尽量实用，不做过度设计，优先让 bug 可复现、让需求可判断

## 测试

- [x] 本地 YAML 解析通过
- [x] 已推到 fork `crper/mori` 的 `main` 并在 GitHub 上验证模板可显示

## 演示

https://github.com/user-attachments/assets/6becbac9-4a4f-4e48-a6e1-3c981e948cea





验证命令：

```bash
ruby -e 'require "yaml"; %w[.github/ISSUE_TEMPLATE/01-bug-report.yml .github/ISSUE_TEMPLATE/02-feature-request.yml .github/ISSUE_TEMPLATE/config.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'
```

## 影响范围

- 仅影响 GitHub 协作配置与文档
- 无运行时代码改动
