### PR TITLE
🐛 fix(ipc): resolve socket path mismatch for CLI inside .app bundle

### DIFF
--- a/Packages/MoriIPC/Sources/MoriIPC/MoriPaths.swift
+++ b/Packages/MoriIPC/Sources/MoriIPC/MoriPaths.swift
@@ -75,32 +75,64 @@ public enum MoriPaths {
     // MARK: - Private Helpers
     
     /// Detects if running as a bundled macOS app vs a development build.
-    /// 
-    /// Bundled app characteristics:
-    /// - Bundle path ends with `.app`
-    /// - Not located in `.build` or `DerivedData` directories
     ///
-    /// Dev build characteristics:
+    /// For the main app executable, `Bundle.main.bundlePath` returns the `.app` bundle root
+    /// (e.g. `/Applications/Mori.app`). But for secondary executables inside the bundle
+    /// (e.g. the `mori` CLI at `Contents/MacOS/bin/mori`), `Bundle.main.bundlePath`
+    /// returns the directory containing that executable — which does NOT end with `.app`.
+    ///
+    /// We therefore check the executable's path, walking up to find a `.app` ancestor,
+    /// which correctly identifies both the main app and any CLI tools shipped inside it.
+    ///
+    /// Dev build characteristics (returned as `false`):
     /// - Running via `swift run` (in `.build` directory)
     /// - Running from `.build-cli` directory
     /// - Running from Xcode `DerivedData`
     private static var isBundledApp: Bool {
+        // Try Bundle.main first — works for the main app executable
         let bundlePath = Bundle.main.bundlePath
-        
-        // Must end with .app to be considered a bundled app
-        guard bundlePath.hasSuffix(".app") else {
-            return false
+        if bundlePath.hasSuffix(".app") && !isInBuildDirectory(bundlePath) {
+            return true
         }
-        
-        // Must NOT be in build directories (use path-segment matching to avoid
-        // false positives on user paths like /Users/DerivedDataUser/)
-        let buildIndicators = ["/.build/", "/.build-cli/", "/DerivedData/"]
-        for indicator in buildIndicators {
-            if bundlePath.contains(indicator) {
-                return false
+
+        // Walk up from the executable path to find a .app ancestor.
+        // This catches the CLI binary at Contents/MacOS/bin/mori where
+        // Bundle.main.bundlePath does NOT point to the .app bundle.
+        let execPath: String
+        if let mainExec = Bundle.main.executablePath {
+            execPath = mainExec
+        } else {
+            execPath = CommandLine.arguments[0]
+        }
+        let resolvedExec = URL(fileURLWithPath: execPath).resolvingSymlinksInPath().path
+
+        return isInAppBundle(resolvedExec)
+    }
+
+    /// Walk up the directory tree looking for a `.app` ancestor directory.
+    static func isInAppBundle(_ path: String) -> Bool {
+        var dir = path
+        while true {
+            let parent = (dir as NSString).deletingLastPathComponent
+            if parent == dir { break } // reached filesystem root
+            dir = parent
+            if dir.hasSuffix(".app") && !isInBuildDirectory(dir) {
+                return true
             }
         }
-        
-        return true
+        return false
+    }
+
+    /// Checks whether a path is inside a known build-output directory,
+    /// using path-segment matching to avoid false positives on user paths
+    /// like `/Users/DerivedDataUser/`.
+    static func isInBuildDirectory(_ path: String) -> Bool {
+        let buildIndicators = ["/.build/", "/.build-cli/", "/DerivedData/"]
+        for indicator in buildIndicators {
+            if path.contains(indicator) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Packages/MoriIPC/Tests/MoriIPCTests/main.swift
+++ b/Packages/MoriIPC/Tests/MoriIPCTests/main.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MoriIPC
+@testable import MoriIPC
 
 // MARK: - IPCCommand Round-trip Tests
 
@@ -292,6 +292,69 @@ func testSplitMessagesNoNewline() {
     assertEqual(String(data: remainder, encoding: .utf8), "partial", "all is remainder")
 }
 
+// MARK: - MoriPaths Tests
+
+func testMoriPathsSocketPathEnvOverride() {
+    setenv("MORI_SOCKET_PATH", "/tmp/custom.sock", 1)
+    defer { unsetenv("MORI_SOCKET_PATH") }
+    assertEqual(MoriPaths.socketPath, "/tmp/custom.sock", "MORI_SOCKET_PATH overrides socket path")
+}
+
+func testMoriPathsAppSupportDirEnvOverride() {
+    setenv("MORI_APP_SUPPORT_DIR", "/tmp/mori-test", 1)
+    defer { unsetenv("MORI_APP_SUPPORT_DIR") }
+    assertEqual(MoriPaths.appSupportDirectory.path, "/tmp/mori-test", "MORI_APP_SUPPORT_DIR overrides app support dir")
+}
+
+func testMoriPathsDefaultSocketPathEndsWithSock() {
+    let path = MoriPaths.socketPath
+    assertTrue(path.hasSuffix("mori.sock"), "default socket path ends with mori.sock, got: \(path)")
+}
+
+func testMoriPathsIsInAppBundlePrimaryExecutable() {
+    // Simulates: /Applications/Mori.app/Contents/MacOS/Mori
+    let path = "/Applications/Mori.app/Contents/MacOS/Mori"
+    assertTrue(MoriPaths.isInAppBundle(path), "primary executable inside .app bundle should be detected")
+}
+
+func testMoriPathsIsInAppBundleSecondaryExecutable() {
+    // Simulates: /Applications/Mori.app/Contents/MacOS/bin/mori
+    // This is the bug scenario — the CLI binary inside the .app bundle
+    let path = "/Applications/Mori.app/Contents/MacOS/bin/mori"
+    assertTrue(MoriPaths.isInAppBundle(path), "CLI binary inside .app bundle should be detected")
+}
+
+func testMoriPathsIsInAppBundleStandaloneBinary() {
+    // No .app ancestor — dev build or standalone CLI
+    let path = "/Users/dev/.build-cli/release/mori"
+    assertFalse(MoriPaths.isInAppBundle(path), "standalone dev build should NOT be detected as bundled")
+}
+
+func testMoriPathsIsInAppBundleSymlinkResolved() {
+    // After symlink resolution, path inside .app should be detected
+    let path = "/Applications/Mori.app/Contents/MacOS/bin/mori"
+    assertTrue(MoriPaths.isInAppBundle(path), "resolved symlink inside .app should be detected")
+}
+
+func testMoriPathsIsInAppBundleBuildDirectory() {
+    // Even if path contains .app but is inside a build directory
+    let path = "/Users/dev/mori/.build-cli/release/Mori.app/Contents/MacOS/Mori"
+    assertFalse(MoriPaths.isInAppBundle(path), ".build-cli path should NOT be detected as bundled")
+}
+
+func testMoriPathsIsInAppBundleDerivedData() {
+    let path = "/Users/dev/DerivedData/Mori-abc/Mori.app/Contents/MacOS/Mori"
+    assertFalse(MoriPaths.isInAppBundle(path), "DerivedData path should NOT be detected as bundled")
+}
+
+func testMoriPathsIsInBuildDirectory() {
+    assertTrue(MoriPaths.isInBuildDirectory("/Users/dev/mori/.build/release/Mori"), "detects .build")
+    assertTrue(MoriPaths.isInBuildDirectory("/Users/dev/mori/.build-cli/release/mori"), "detects .build-cli")
+    assertTrue(MoriPaths.isInBuildDirectory("/Users/dev/Library/Developer/Xcode/DerivedData/Mori-xyz"), "detects DerivedData")
+    assertFalse(MoriPaths.isInBuildDirectory("/Users/DerivedDataUser/mori"), "no false positive on user path with DerivedData")
+    assertFalse(MoriPaths.isInBuildDirectory("/Applications/Mori.app"), "no false positive on .app bundle")
+}
+
 // MARK: - Run All Tests
 
 print("Running MoriIPC tests...")
@@ -341,6 +404,18 @@ testSplitMessagesMultiple()
 testSplitMessagesIncomplete()
 testSplitMessagesEmpty()
 testSplitMessagesNoNewline()
+
+// MoriPaths
+testMoriPathsSocketPathEnvOverride()
+testMoriPathsAppSupportDirEnvOverride()
+testMoriPathsDefaultSocketPathEndsWithSock()
+testMoriPathsIsInAppBundlePrimaryExecutable()
+testMoriPathsIsInAppBundleSecondaryExecutable()
+testMoriPathsIsInAppBundleStandaloneBinary()
+testMoriPathsIsInAppBundleSymlinkResolved()
+testMoriPathsIsInAppBundleBuildDirectory()
+testMoriPathsIsInAppBundleDerivedData()
+testMoriPathsIsInBuildDirectory()
 
 printResults()
 


### PR DESCRIPTION
## Fix: `mori` CLI IPC socket path mismatch

### Problem

The `mori` CLI could not communicate with the running Mori.app. Commands like `mori project list` failed with:

```
Launching Mori.app…
Error: Mori.app launched but IPC socket not ready after 10s.
```

The IPC server was healthy (direct socket connection worked), but the CLI was looking for the socket in the wrong directory.

### Root Cause

`MoriPaths.isBundledApp` relied on `Bundle.main.bundlePath.hasSuffix(".app")` to decide whether to use the production directory (`~/Library/Application Support/Mori/`) or the dev directory (`~/Library/Application Support/Mori-Dev/`).

This works for the main app executable (`/Applications/Mori.app/Contents/MacOS/Mori`), where `Bundle.main.bundlePath` correctly returns `/Applications/Mori.app`. But for the `mori` CLI binary at `/Applications/Mori.app/Contents/MacOS/bin/mori`, macOS sets `Bundle.main.bundlePath` to the **directory containing the executable** (`.../Contents/MacOS/bin/`), not the `.app` bundle root. Since that path does not end with `.app`, `isBundledApp` returned `false`, and the CLI resolved the socket to `~/Library/Application Support/Mori-Dev/mori.sock` — which does not exist.

### Fix

Restructured `isBundledApp` to also walk up the executable path (with symlinks resolved) looking for a `.app` ancestor directory. This correctly identifies both the main app and secondary executables (like the CLI) shipped inside the bundle, while still excluding dev builds in `.build`, `.build-cli`, and `DerivedData`.

### Changes

- **`MoriIPC/MoriPaths.swift`** — Rewrote `isBundledApp` to check executable path ancestors in addition to `Bundle.main.bundlePath`. Extracted `isInAppBundle(_:)` and `isInBuildDirectory(_:)` as internal helpers.
- **`MoriIPCTests/main.swift`** — Added 14 assertions covering `isInAppBundle`, `isInBuildDirectory`, env-var overrides, and the bug scenario (CLI at `Contents/MacOS/bin/mori`).

### Testing

```
mise run test     # All 1,115 assertions pass (76 IPC, 678 Core, 249 Tmux, 64 Persistence, 48 Keybindings)
```