### PR TITLE
✨ feat: add Droid agent status hook support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
                 .copy("Resources/mori-hook-common.sh"),
                 .copy("Resources/mori-agent-hook.sh"),
                 .copy("Resources/mori-codex-hook.sh"),
+                .copy("Resources/mori-droid-hook.sh"),
                 .copy("Resources/mori-pi-extension.ts"),
                 .process("Resources/en.lproj"),
                 .process("Resources/zh-Hans.lproj"),

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -120,11 +120,13 @@ public struct AgentHookModel: Equatable {
     public var claudeEnabled: Bool
     public var codexEnabled: Bool
     public var piEnabled: Bool
+    public var droidEnabled: Bool
 
-    public init(claudeEnabled: Bool = false, codexEnabled: Bool = false, piEnabled: Bool = false) {
+    public init(claudeEnabled: Bool = false, codexEnabled: Bool = false, piEnabled: Bool = false, droidEnabled: Bool = false) {
         self.claudeEnabled = claudeEnabled
         self.codexEnabled = codexEnabled
         self.piEnabled = piEnabled
+        self.droidEnabled = droidEnabled
     }
 }
 
@@ -1381,6 +1383,13 @@ private struct AgentHookSettingsContent: View {
             icon: "sparkle",
             description: .localized("Registers an extension in Pi's settings.json for agent start, end, and tool execution events."),
             isEnabled: $model.piEnabled
+        )
+
+        agentCard(
+            name: .localized("Droid"),
+            icon: "cpu",
+            description: .localized("Adds hooks to ~/.factory/settings.json for prompt submit, tool use, stop, and notification events."),
+            isEnabled: $model.droidEnabled
         )
     }
 

--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "Default" = "Default";
 "Directional Pane Nav" = "Directional Pane Nav";
 "Distribute extra padding evenly around the terminal content to center it within the window." = "Distribute extra padding evenly around the terminal content to center it within the window.";
+"Droid" = "Droid";
+"Adds hooks to ~/.factory/settings.json for prompt submit, tool use, stop, and notification events." = "Adds hooks to ~/.factory/settings.json for prompt submit, tool use, stop, and notification events.";
 "Equalize Panes" = "Equalize Panes";
 "Error" = "Error";
 "Filter fonts…" = "Filter fonts…";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "Default" = "默认";
 "Directional Pane Nav" = "方向键面板导航";
 "Distribute extra padding evenly around the terminal content to center it within the window." = "在终端内容周围均匀分配额外边距，使其在窗口中居中。";
+"Droid" = "Droid";
+"Adds hooks to ~/.factory/settings.json for prompt submit, tool use, stop, and notification events." = "向 ~/.factory/settings.json 添加钩子，用于提示提交、工具使用、停止和通知事件。";
 "Equalize Panes" = "均分面板";
 "Error" = "错误";
 "Filter fonts…" = "筛选字体…";

--- a/Sources/Mori/App/AgentHookConfigurator.swift
+++ b/Sources/Mori/App/AgentHookConfigurator.swift
@@ -12,10 +12,14 @@ enum AgentHookConfigurator {
         "claude": "Claude Code",
         "codex": "Codex",
         "pi": "Pi",
+        "droid": "Droid",
     ]
 
     /// Claude Code hook event names (used for both install and uninstall).
     private static let claudeEvents = ["UserPromptSubmit", "PreToolUse", "Stop", "Notification"]
+
+    /// Droid hook event names (same lifecycle events as Claude Code).
+    private static let droidEvents = ["UserPromptSubmit", "PreToolUse", "Stop", "Notification"]
 
     private static let home = FileManager.default.homeDirectoryForCurrentUser
 
@@ -37,6 +41,15 @@ enum AgentHookConfigurator {
 
     private static var codexHookPath: String {
         hooksDir.appendingPathComponent("mori-codex-hook.sh").path
+    }
+
+    private static var droidHookPath: String {
+        hooksDir.appendingPathComponent("mori-droid-hook.sh").path
+    }
+
+    /// Factory (Droid) settings: ~/.factory/settings.json
+    private static var factorySettingsURL: URL {
+        home.appendingPathComponent(".factory/settings.json")
     }
 
     /// Pi config directory: $PI_CODING_AGENT_DIR or ~/.pi/agent
@@ -69,6 +82,14 @@ enum AgentHookConfigurator {
         return content.contains(codexHookPath)
     }
 
+    /// Check if Droid hooks are installed in ~/.factory/settings.json.
+    static func isDroidHookInstalled() -> Bool {
+        guard let data = try? Data(contentsOf: factorySettingsURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = json["hooks"] as? [String: Any] else { return false }
+        return hookEntryExists(in: hooks, event: "Stop", command: "\(droidHookPath) Stop")
+    }
+
     /// Check if Pi extension is installed and registered in ~/.pi/agent/settings.json.
     static func isPiExtensionInstalled() -> Bool {
         guard FileManager.default.fileExists(atPath: piExtensionURL.path) else { return false }
@@ -99,6 +120,15 @@ enum AgentHookConfigurator {
         guard let source = loadBundledResource("mori-codex-hook", ext: "sh"),
               let path = installScript(name: "mori-codex-hook", source: source) else { return }
         configureCodexSettings(hookPath: path)
+    }
+
+    /// Install Droid hook and register in ~/.factory/settings.json.
+    static func installDroidHook() {
+        ensureHooksDir()
+        installCommonScript()
+        guard let source = loadBundledResource("mori-droid-hook", ext: "sh"),
+              let path = installScript(name: "mori-droid-hook", source: source) else { return }
+        configureDroidSettings(hookPath: path)
     }
 
     /// Install Pi extension to mori config dir and register in Pi's settings.json.
@@ -164,6 +194,35 @@ enum AgentHookConfigurator {
             try? cleaned.write(to: configURL, atomically: true, encoding: .utf8)
         }
         try? FileManager.default.removeItem(atPath: codexHookPath)
+    }
+
+    /// Remove Droid hooks from ~/.factory/settings.json and delete hook script.
+    static func uninstallDroidHook() {
+        if let data = try? Data(contentsOf: factorySettingsURL),
+           var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           var hooks = json["hooks"] as? [String: Any] {
+            var changed = false
+            for event in droidEvents {
+                let command = "\(droidHookPath) \(event)"
+                if removeHookEntry(from: &hooks, event: event, command: command) {
+                    changed = true
+                }
+            }
+            if changed {
+                for (key, value) in hooks {
+                    if let arr = value as? [[String: Any]], arr.isEmpty {
+                        hooks.removeValue(forKey: key)
+                    }
+                }
+                if hooks.isEmpty {
+                    json.removeValue(forKey: "hooks")
+                } else {
+                    json["hooks"] = hooks
+                }
+                writeJSON(json, to: factorySettingsURL)
+            }
+        }
+        try? FileManager.default.removeItem(atPath: droidHookPath)
     }
 
     /// Remove Pi extension file and unregister from settings.json.
@@ -290,6 +349,40 @@ enum AgentHookConfigurator {
         }
         let config = lines.joined(separator: "\n")
         try? config.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Droid
+
+    private static func configureDroidSettings(hookPath: String) {
+        var settings: [String: Any] = [:]
+        if let data = try? Data(contentsOf: factorySettingsURL),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            settings = json
+        }
+
+        var hooks = settings["hooks"] as? [String: Any] ?? [:]
+        var changed = false
+
+        for event in droidEvents {
+            let command = "\(hookPath) \(event)"
+            if !hookEntryExists(in: hooks, event: event, command: command) {
+                let entry: [String: Any] = [
+                    "hooks": [["type": "command", "command": command]]
+                ]
+                var eventHooks = hooks[event] as? [[String: Any]] ?? []
+                eventHooks.append(entry)
+                hooks[event] = eventHooks
+                changed = true
+            }
+        }
+
+        guard changed else { return }
+
+        try? FileManager.default.createDirectory(
+            at: factorySettingsURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        settings["hooks"] = hooks
+        writeJSON(settings, to: factorySettingsURL)
     }
 
     // MARK: - Pi

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -684,7 +684,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             initialAgentHooks: AgentHookModel(
                 claudeEnabled: AgentHookConfigurator.isClaudeHookInstalled(),
                 codexEnabled: AgentHookConfigurator.isCodexHookInstalled(),
-                piEnabled: AgentHookConfigurator.isPiExtensionInstalled()
+                piEnabled: AgentHookConfigurator.isPiExtensionInstalled(),
+                droidEnabled: AgentHookConfigurator.isDroidHookInstalled()
             ),
             initialProxy: ProxySettingsApplicator.load(),
             onChanged: { [weak self] newModel in
@@ -1568,6 +1569,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             AgentHookConfigurator.installPiExtension()
         } else {
             AgentHookConfigurator.uninstallPiExtension()
+        }
+        if model.droidEnabled {
+            AgentHookConfigurator.installDroidHook()
+        } else {
+            AgentHookConfigurator.uninstallDroidHook()
         }
     }
 

--- a/Sources/Mori/Resources/mori-droid-hook.sh
+++ b/Sources/Mori/Resources/mori-droid-hook.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Mori agent hook for Factory Droid
+# Sets tmux pane options and renames window on agent state transitions.
+
+set -euo pipefail
+
+HOOK_TYPE="${1:-}"
+AGENT_NAME="droid"
+
+# Read JSON from stdin (required by Droid hooks)
+cat > /dev/null 2>&1 || true
+
+# Bail if not inside tmux
+[ -z "${TMUX:-}" ] && exit 0
+
+# shellcheck source=mori-hook-common.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/mori-hook-common.sh"
+
+case "$HOOK_TYPE" in
+    UserPromptSubmit|PreToolUse)
+        set_state "working"
+        ;;
+    Stop|Notification)
+        set_state "waiting"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Add Factory Droid as a fourth agent integration in Mori, on par with Claude Code, Codex CLI, and Pi.

## Changes

- **New hook script** (`mori-droid-hook.sh`): Maps Droid lifecycle events to tmux pane options (`@mori-agent-state` / `@mori-agent-name`)
- **AgentHookConfigurator**: `isDroidHookInstalled()`, `installDroidHook()`, `uninstallDroidHook()` — reads/writes `~/.factory/settings.json`
- **Settings UI**: Droid toggle in Settings > Agent Hooks
- **AppDelegate**: Wires detect/install/uninstall on toggle
- **Localization**: en + zh-Hans strings

## How it works

When enabled, Mori registers hook entries in `~/.factory/settings.json` for `UserPromptSubmit`, `PreToolUse`, `Stop`, and `Notification` events. The hook script sets tmux pane options that Mori already polls every 5s, producing the same badges/tab names/notifications as other agents.

## Testing

- All existing tests pass (`mise run test`)
- Release builds succeed for both `Mori` (app) and `mori` (CLI)