### PR TITLE
✨ feat: inherit Ghostty translucency, blur, and tmux cell opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur`, applies Ghostty window opacity/blur to the main workspace window and settings window, and exposes blur controls in Settings
+- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur`, applies Ghostty window opacity/blur to the main workspace window, exposes blur controls in Settings, and adds macOS 26 glass background polish for terminal content
 
 ## [0.3.3] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Features
+
+- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur`, applies Ghostty window opacity/blur to the main workspace window and settings window, and exposes blur controls in Settings
+
 ## [0.3.3] - 2026-04-05
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur`, applies Ghostty window opacity/blur to the main workspace window, exposes blur controls in Settings, and adds macOS 26 glass background polish for terminal content
+- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur` and `background-opacity-cells`, applies Ghostty window opacity/blur to the main workspace window, exposes translucency controls in Settings, improves tmux translucency by avoiding forced opaque backgrounds when cell opacity is disabled, and adds macOS 26 glass background polish for terminal content
 
 ## [0.3.3] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur` and `background-opacity-cells`, applies Ghostty window opacity/blur to the main workspace window, exposes translucency controls in Settings, improves tmux translucency by avoiding forced opaque backgrounds when cell opacity is disabled, and adds macOS 26 glass background polish for terminal content
+- Start Ghostty translucency inheritance: Mori now reads and persists `background-blur` and `background-opacity-cells`, applies Ghostty window opacity/blur to the main workspace window, exposes translucency controls in Settings, improves tmux translucency by avoiding forced opaque backgrounds when cell opacity is disabled, adds macOS 26 glass background polish for terminal content, and avoids redundant tmux theme reapplication with debounced updates
 
 ## [0.3.3] - 2026-04-05
 

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyAdapter.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyAdapter.swift
@@ -35,17 +35,28 @@ public final class GhosttyAdapter: TerminalHost {
         GhosttyApp.shared.reloadConfig()
     }
 
-    /// Apply Ghostty-derived window translucency and blur to an NSWindow.
-    public func syncWindowAppearance(_ window: NSWindow) {
+    /// Apply Ghostty-derived window translucency and blur to the main workspace window.
+    public func syncWorkspaceWindowAppearance(_ window: NSWindow) {
+        applyWindowAppearance(window, allowsTransparency: true)
+    }
+
+    /// Apply Ghostty theme colors to a non-terminal window while keeping it opaque.
+    public func syncThemedWindowAppearance(_ window: NSWindow) {
+        applyWindowAppearance(window, allowsTransparency: false)
+    }
+
+    private func applyWindowAppearance(_ window: NSWindow, allowsTransparency: Bool) {
         let themeInfo = self.themeInfo
         window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
 
-        let useTransparentBackground = !window.styleMask.contains(.fullScreen) && themeInfo.usesTransparentWindowBackground
+        let useTransparentBackground = allowsTransparency && !window.styleMask.contains(.fullScreen) && themeInfo.usesTransparentWindowBackground
         if useTransparentBackground {
             window.isOpaque = false
             window.backgroundColor = .white.withAlphaComponent(0.001)
 
-            if !themeInfo.backgroundBlur.isGlassStyle, let app = GhosttyApp.shared.app {
+            if window.isVisible,
+               !themeInfo.backgroundBlur.isGlassStyle,
+               let app = GhosttyApp.shared.app {
                 ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
             }
         } else {

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyAdapter.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyAdapter.swift
@@ -35,6 +35,25 @@ public final class GhosttyAdapter: TerminalHost {
         GhosttyApp.shared.reloadConfig()
     }
 
+    /// Apply Ghostty-derived window translucency and blur to an NSWindow.
+    public func syncWindowAppearance(_ window: NSWindow) {
+        let themeInfo = self.themeInfo
+        window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+
+        let useTransparentBackground = !window.styleMask.contains(.fullScreen) && themeInfo.usesTransparentWindowBackground
+        if useTransparentBackground {
+            window.isOpaque = false
+            window.backgroundColor = .white.withAlphaComponent(0.001)
+
+            if !themeInfo.backgroundBlur.isGlassStyle, let app = GhosttyApp.shared.app {
+                ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
+            }
+        } else {
+            window.isOpaque = true
+            window.backgroundColor = themeInfo.background.withAlphaComponent(1)
+        }
+    }
+
     public func createSurface(command: String, workingDirectory: String) -> NSView {
         guard let app = GhosttyApp.shared.app else {
             NSLog("[GhosttyAdapter] GhosttyApp not initialized, falling back to empty view")

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
@@ -5,18 +5,72 @@ import GhosttyKit
 /// Resolved theme colors extracted from ghostty's config.
 /// Queried once at startup via `ghostty_config_get` before the config is consumed.
 public struct GhosttyThemeInfo: Sendable {
+    public enum BackgroundBlur: Sendable, Equatable {
+        case disabled
+        case radius(Int)
+        case macosGlassRegular
+        case macosGlassClear
+
+        var isEnabled: Bool {
+            switch self {
+            case .disabled: false
+            default: true
+            }
+        }
+
+        var isGlassStyle: Bool {
+            switch self {
+            case .macosGlassRegular, .macosGlassClear: true
+            default: false
+            }
+        }
+
+        static func from(cValue: Int16) -> BackgroundBlur {
+            switch cValue {
+            case 0:
+                .disabled
+            case -1:
+                if #available(macOS 26.0, *) {
+                    .macosGlassRegular
+                } else {
+                    .disabled
+                }
+            case -2:
+                if #available(macOS 26.0, *) {
+                    .macosGlassClear
+                } else {
+                    .disabled
+                }
+            default:
+                .radius(Int(cValue))
+            }
+        }
+    }
+
     public let background: NSColor
     public let foreground: NSColor
     /// ANSI palette (16 standard colors, indices 0-15).
     public let palette: [NSColor]
     public let isDark: Bool
+    public let backgroundOpacity: Double
+    public let backgroundBlur: BackgroundBlur
+
+    public var effectiveBackground: NSColor {
+        background.withAlphaComponent(backgroundOpacity)
+    }
+
+    public var usesTransparentWindowBackground: Bool {
+        backgroundOpacity < 1 || backgroundBlur.isGlassStyle
+    }
 
     /// Default fallback when config cannot be queried.
     public static let fallback = GhosttyThemeInfo(
         background: .black,
         foreground: .white,
         palette: (0..<16).map { _ in .gray },
-        isDark: true
+        isDark: true,
+        backgroundOpacity: 1,
+        backgroundBlur: .disabled
     )
 
     /// Query theme colors from a finalized ghostty config.
@@ -24,6 +78,8 @@ public struct GhosttyThemeInfo: Sendable {
     static func from(config: ghostty_config_t) -> GhosttyThemeInfo {
         let bg = queryColor(config, key: "background") ?? NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1)
         let fg = queryColor(config, key: "foreground") ?? NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1)
+        let backgroundOpacity = queryDouble(config, key: "background-opacity") ?? 1
+        let backgroundBlur = queryBackgroundBlur(config, key: "background-blur") ?? .disabled
 
         // Query palette — ghostty_config_palette_s contains a 256-element C array
         // which Swift imports as a massive tuple. Use withUnsafePointer to access by index.
@@ -61,7 +117,9 @@ public struct GhosttyThemeInfo: Sendable {
             background: bg,
             foreground: fg,
             palette: palette,
-            isDark: luminance < 0.5
+            isDark: luminance < 0.5,
+            backgroundOpacity: max(0.001, min(backgroundOpacity, 1)),
+            backgroundBlur: backgroundBlur
         )
     }
 
@@ -85,6 +143,22 @@ public struct GhosttyThemeInfo: Sendable {
             blue: CGFloat(color.b) / 255.0,
             alpha: 1.0
         )
+    }
+
+    private static func queryDouble(_ config: ghostty_config_t, key: String) -> Double? {
+        var value: Double = 0
+        let success = withUnsafeMutablePointer(to: &value) { ptr in
+            ghostty_config_get(config, ptr, key, UInt(key.count))
+        }
+        return success ? value : nil
+    }
+
+    private static func queryBackgroundBlur(_ config: ghostty_config_t, key: String) -> BackgroundBlur? {
+        var value: Int16 = 0
+        let success = withUnsafeMutablePointer(to: &value) { ptr in
+            ghostty_config_get(config, ptr, key, UInt(key.count))
+        }
+        return success ? BackgroundBlur.from(cValue: value) : nil
     }
 }
 #endif

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
@@ -53,6 +53,7 @@ public struct GhosttyThemeInfo: Sendable {
     public let palette: [NSColor]
     public let isDark: Bool
     public let backgroundOpacity: Double
+    public let backgroundOpacityCells: Bool
     public let backgroundBlur: BackgroundBlur
 
     public var effectiveBackground: NSColor {
@@ -70,6 +71,7 @@ public struct GhosttyThemeInfo: Sendable {
         palette: (0..<16).map { _ in .gray },
         isDark: true,
         backgroundOpacity: 1,
+        backgroundOpacityCells: false,
         backgroundBlur: .disabled
     )
 
@@ -79,6 +81,7 @@ public struct GhosttyThemeInfo: Sendable {
         let bg = queryColor(config, key: "background") ?? NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1)
         let fg = queryColor(config, key: "foreground") ?? NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1)
         let backgroundOpacity = queryDouble(config, key: "background-opacity") ?? 1
+        let backgroundOpacityCells = queryBool(config, key: "background-opacity-cells") ?? false
         let backgroundBlur = queryBackgroundBlur(config, key: "background-blur") ?? .disabled
 
         // Query palette — ghostty_config_palette_s contains a 256-element C array
@@ -119,6 +122,7 @@ public struct GhosttyThemeInfo: Sendable {
             palette: palette,
             isDark: luminance < 0.5,
             backgroundOpacity: max(0.001, min(backgroundOpacity, 1)),
+            backgroundOpacityCells: backgroundOpacityCells,
             backgroundBlur: backgroundBlur
         )
     }
@@ -147,6 +151,14 @@ public struct GhosttyThemeInfo: Sendable {
 
     private static func queryDouble(_ config: ghostty_config_t, key: String) -> Double? {
         var value: Double = 0
+        let success = withUnsafeMutablePointer(to: &value) { ptr in
+            ghostty_config_get(config, ptr, key, UInt(key.count))
+        }
+        return success ? value : nil
+    }
+
+    private static func queryBool(_ config: ghostty_config_t, key: String) -> Bool? {
+        var value = false
         let success = withUnsafeMutablePointer(to: &value) { ptr in
             ghostty_config_get(config, ptr, key, UInt(key.count))
         }

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyThemeInfo.swift
@@ -11,14 +11,14 @@ public struct GhosttyThemeInfo: Sendable {
         case macosGlassRegular
         case macosGlassClear
 
-        var isEnabled: Bool {
+        public var isEnabled: Bool {
             switch self {
             case .disabled: false
             default: true
             }
         }
 
-        var isGlassStyle: Bool {
+        public var isGlassStyle: Bool {
             switch self {
             case .macosGlassRegular, .macosGlassClear: true
             default: false

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -753,6 +753,14 @@ private struct ThemeSettingsContent: View {
                                 .frame(width: 140)
                         }
                     }
+
+                    if model.backgroundOpacity >= 1, model.backgroundBlur != .disabled {
+                        Text(String.localized("Background blur is only visible when background opacity is below 1.0."))
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 180, alignment: .leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
             }
         }

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -64,6 +64,7 @@ public struct GhosttySettingsModel: Equatable {
     public var cursorStyle: String
     public var cursorBlink: Bool
     public var backgroundOpacity: Double
+    public var backgroundOpacityCells: Bool
     public var backgroundBlur: GhosttyBackgroundBlur
     public var macosOptionAsAlt: String
     public var mouseHideWhileTyping: Bool
@@ -79,6 +80,7 @@ public struct GhosttySettingsModel: Equatable {
         cursorStyle: String = "block",
         cursorBlink: Bool = true,
         backgroundOpacity: Double = 1.0,
+        backgroundOpacityCells: Bool = false,
         backgroundBlur: GhosttyBackgroundBlur = .disabled,
         macosOptionAsAlt: String = "false",
         mouseHideWhileTyping: Bool = false,
@@ -93,6 +95,7 @@ public struct GhosttySettingsModel: Equatable {
         self.cursorStyle = cursorStyle
         self.cursorBlink = cursorBlink
         self.backgroundOpacity = backgroundOpacity
+        self.backgroundOpacityCells = backgroundOpacityCells
         self.backgroundBlur = backgroundBlur
         self.macosOptionAsAlt = macosOptionAsAlt
         self.mouseHideWhileTyping = mouseHideWhileTyping
@@ -722,6 +725,17 @@ private struct ThemeSettingsContent: View {
                         .frame(width: 140)
                         .onChange(of: model.backgroundOpacity) { _, _ in onChanged() }
                 }
+            }
+
+            CardDivider()
+
+            SettingRow(
+                title: .localized("Apply opacity to colored cells"),
+                description: .localized("Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background.")
+            ) {
+                Toggle("", isOn: $model.backgroundOpacityCells)
+                    .labelsHidden()
+                    .onChange(of: model.backgroundOpacityCells) { _, _ in onChanged() }
             }
 
             CardDivider()

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -3,6 +3,60 @@ import MoriCore
 
 /// Settings model representing user-facing ghostty config options.
 /// Read from and written to ~/.config/ghostty/config.
+public enum GhosttyBackgroundBlur: Equatable {
+    case disabled
+    case standard
+    case radius(Int)
+    case macosGlassRegular
+    case macosGlassClear
+
+    public init(configValue: String) {
+        let value = configValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch value {
+        case "", "false", "0":
+            self = .disabled
+        case "true":
+            self = .standard
+        case "macos-glass-regular":
+            self = .macosGlassRegular
+        case "macos-glass-clear":
+            self = .macosGlassClear
+        default:
+            if let radius = Int(value), radius > 0 {
+                self = .radius(radius)
+            } else {
+                self = .disabled
+            }
+        }
+    }
+
+    public var configValue: String {
+        switch self {
+        case .disabled:
+            "false"
+        case .standard:
+            "true"
+        case .radius(let value):
+            "\(max(1, value))"
+        case .macosGlassRegular:
+            "macos-glass-regular"
+        case .macosGlassClear:
+            "macos-glass-clear"
+        }
+    }
+
+    public var radiusValue: Int {
+        switch self {
+        case .radius(let value):
+            max(1, value)
+        case .standard:
+            20
+        default:
+            20
+        }
+    }
+}
+
 public struct GhosttySettingsModel: Equatable {
     public var fontFamily: String
     public var fontSize: Int
@@ -10,6 +64,7 @@ public struct GhosttySettingsModel: Equatable {
     public var cursorStyle: String
     public var cursorBlink: Bool
     public var backgroundOpacity: Double
+    public var backgroundBlur: GhosttyBackgroundBlur
     public var macosOptionAsAlt: String
     public var mouseHideWhileTyping: Bool
     public var mouseScrollMultiplier: Int
@@ -24,6 +79,7 @@ public struct GhosttySettingsModel: Equatable {
         cursorStyle: String = "block",
         cursorBlink: Bool = true,
         backgroundOpacity: Double = 1.0,
+        backgroundBlur: GhosttyBackgroundBlur = .disabled,
         macosOptionAsAlt: String = "false",
         mouseHideWhileTyping: Bool = false,
         mouseScrollMultiplier: Int = 1,
@@ -37,6 +93,7 @@ public struct GhosttySettingsModel: Equatable {
         self.cursorStyle = cursorStyle
         self.cursorBlink = cursorBlink
         self.backgroundOpacity = backgroundOpacity
+        self.backgroundBlur = backgroundBlur
         self.macosOptionAsAlt = macosOptionAsAlt
         self.mouseHideWhileTyping = mouseHideWhileTyping
         self.mouseScrollMultiplier = mouseScrollMultiplier
@@ -535,11 +592,60 @@ private struct GeneralSettingsContent: View {
 // MARK: - Theme Settings
 
 private struct ThemeSettingsContent: View {
+    private enum BackgroundBlurPreset: String, CaseIterable, Identifiable {
+        case disabled
+        case standard
+        case custom
+        case macosGlassRegular
+        case macosGlassClear
+
+        var id: String { rawValue }
+    }
+
     @Binding var model: GhosttySettingsModel
     let availableThemes: [String]
     let onChanged: () -> Void
 
     @State private var themeSearch = ""
+
+    private var blurPreset: Binding<BackgroundBlurPreset> {
+        Binding(
+            get: {
+                switch model.backgroundBlur {
+                case .disabled: .disabled
+                case .standard: .standard
+                case .radius: .custom
+                case .macosGlassRegular: .macosGlassRegular
+                case .macosGlassClear: .macosGlassClear
+                }
+            },
+            set: { preset in
+                switch preset {
+                case .disabled:
+                    model.backgroundBlur = .disabled
+                case .standard:
+                    model.backgroundBlur = .standard
+                case .custom:
+                    model.backgroundBlur = .radius(model.backgroundBlur.radiusValue)
+                case .macosGlassRegular:
+                    model.backgroundBlur = .macosGlassRegular
+                case .macosGlassClear:
+                    model.backgroundBlur = .macosGlassClear
+                }
+                onChanged()
+            }
+        )
+    }
+
+    private var blurRadius: Binding<Double> {
+        Binding(
+            get: { Double(model.backgroundBlur.radiusValue) },
+            set: { newValue in
+                model.backgroundBlur = .radius(Int(newValue.rounded()))
+                onChanged()
+            }
+        )
+    }
 
     var body: some View {
         // Preview
@@ -615,6 +721,38 @@ private struct ThemeSettingsContent: View {
                     Slider(value: $model.backgroundOpacity, in: 0.1...1.0, step: 0.05)
                         .frame(width: 140)
                         .onChange(of: model.backgroundOpacity) { _, _ in onChanged() }
+                }
+            }
+
+            CardDivider()
+
+            SettingRow(
+                title: .localized("Background blur"),
+                description: .localized("Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.")
+            ) {
+                VStack(alignment: .trailing, spacing: 8) {
+                    Picker("", selection: blurPreset) {
+                        Text(String.localized("Off")).tag(BackgroundBlurPreset.disabled)
+                        Text(String.localized("Standard Blur")).tag(BackgroundBlurPreset.standard)
+                        Text(String.localized("Custom Blur Radius")).tag(BackgroundBlurPreset.custom)
+                        if #available(macOS 26.0, *) {
+                            Text(String.localized("Glass Regular")).tag(BackgroundBlurPreset.macosGlassRegular)
+                            Text(String.localized("Glass Clear")).tag(BackgroundBlurPreset.macosGlassClear)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 180)
+
+                    if case .radius = model.backgroundBlur {
+                        HStack(spacing: 8) {
+                            Text("\(model.backgroundBlur.radiusValue)")
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 28)
+                            Slider(value: blurRadius, in: 1...60, step: 1)
+                                .frame(width: 140)
+                        }
+                    }
                 }
             }
         }

--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "Automatically hide the mouse cursor when typing in the terminal." = "Automatically hide the mouse cursor when typing in the terminal.";
 "Available Monospace Fonts" = "Available Monospace Fonts";
 "Background opacity" = "Background opacity";
+"Background blur" = "Background blur";
+"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.";
+"Background blur is only visible when background opacity is below 1.0." = "Background blur is only visible when background opacity is below 1.0.";
+"Apply opacity to colored cells" = "Apply opacity to colored cells";
+"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background.";
 "Balance window padding" = "Balance window padding";
 "Bar" = "Bar";
 "Block" = "Block";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "Automatically hide the mouse cursor when typing in the terminal." = "在终端中输入时自动隐藏鼠标光标。";
 "Available Monospace Fonts" = "可用等宽字体";
 "Background opacity" = "背景透明度";
+"Background blur" = "背景模糊";
+"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "为半透明终端背景继承 Ghostty 的窗口模糊与玻璃效果样式。";
+"Background blur is only visible when background opacity is below 1.0." = "仅当背景不透明度低于 1.0 时，背景模糊才会可见。";
+"Apply opacity to colored cells" = "将不透明度应用到彩色单元格";
+"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "当 tmux 或终端应用绘制彩色单元格而不是使用默认终端背景时，也让这些背景保持半透明。";
 "Balance window padding" = "平衡窗口边距";
 "Bar" = "竖线";
 "Block" = "方块";

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -780,6 +780,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             cursorStyle: cf.get("cursor-style") ?? "block",
             cursorBlink: (cf.get("cursor-style-blink") ?? "true") != "false",
             backgroundOpacity: Double(cf.get("background-opacity") ?? "1.0") ?? 1.0,
+            backgroundOpacityCells: cf.get("background-opacity-cells") == "true",
             backgroundBlur: GhosttyBackgroundBlur(configValue: cf.get("background-blur") ?? "false"),
             macosOptionAsAlt: cf.get("macos-option-as-alt") ?? "false",
             mouseHideWhileTyping: cf.get("mouse-hide-while-typing") == "true",
@@ -809,6 +810,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         cf.set("cursor-style", value: model.cursorStyle)
         cf.set("cursor-style-blink", value: model.cursorBlink ? "true" : "false")
         cf.set("background-opacity", value: String(format: "%.2f", model.backgroundOpacity))
+        cf.set("background-opacity-cells", value: model.backgroundOpacityCells ? "true" : "false")
         cf.set("background-blur", value: model.backgroundBlur.configValue)
         cf.set("macos-option-as-alt", value: model.macosOptionAsAlt)
         cf.set("mouse-hide-while-typing", value: model.mouseHideWhileTyping ? "true" : "false")

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -848,7 +848,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func refreshGhosttyThemeBackgrounds(themeInfo: GhosttyThemeInfo) {
         sidebarController?.updateAppearance(themeInfo: themeInfo)
-        terminalAreaController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
+        terminalAreaController?.updateAppearance(
+            themeInfo: themeInfo,
+            isKeyWindow: mainWindowController?.window?.isKeyWindow ?? true
+        )
     }
 
     // MARK: - Proxy

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -109,10 +109,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Build the window with ghostty theme
         let windowController = MainWindowController(themeInfo: themeInfo)
         self.mainWindowController = windowController
-        if let adapter = terminalArea.terminalHost as? GhosttyAdapter,
-           let window = windowController.window {
-            adapter.syncWindowAppearance(window)
-        }
 
         // Build split view children
         let sidebarController = SidebarHostingController(
@@ -235,9 +231,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowController.onShowCreateWorktreePanel = { [weak self] in
             self?.showCreateWorktreePanel()
         }
+        windowController.onWindowAppearanceInvalidated = { [weak self, weak terminalArea, weak windowController] in
+            guard let self,
+                  let adapter = terminalArea?.terminalHost as? GhosttyAdapter,
+                  let window = windowController?.window else { return }
+            adapter.syncWorkspaceWindowAppearance(window)
+            self.refreshGhosttyThemeBackgrounds(themeInfo: adapter.themeInfo)
+        }
 
         windowController.contentViewController = splitVC
         windowController.showWindow(nil)
+        if let adapter = terminalArea.terminalHost as? GhosttyAdapter,
+           let window = windowController.window {
+            adapter.syncWorkspaceWindowAppearance(window)
+        }
         // Restore saved frame after all layout is complete
         windowController.restoreSavedFrame()
         NSApp.activate(ignoringOtherApps: true)
@@ -745,14 +752,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let hostingController = NSHostingController(rootView: settingsView)
         hostingController.view.wantsLayer = true
-        hostingController.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
+        hostingController.view.layer?.backgroundColor = themeInfo.background.cgColor
         let window = NSWindow(contentViewController: hostingController)
         window.title = .localized("Settings")
         window.styleMask = [.titled, .closable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         if let adapter = terminalAreaController?.terminalHost as? GhosttyAdapter {
-            adapter.syncWindowAppearance(window)
+            adapter.syncThemedWindowAppearance(window)
         } else {
             window.backgroundColor = themeInfo.background
             window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
@@ -817,16 +824,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let themeInfo = adapter.themeInfo
         if let window = mainWindowController?.window {
-            adapter.syncWindowAppearance(window)
+            adapter.syncWorkspaceWindowAppearance(window)
         }
-        sidebarController?.updateAppearance(themeInfo: themeInfo)
-        terminalAreaController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
+        refreshGhosttyThemeBackgrounds(themeInfo: themeInfo)
 
         // Update settings window appearance
         if let settingsWindow = settingsWindowController?.window {
-            adapter.syncWindowAppearance(settingsWindow)
+            adapter.syncThemedWindowAppearance(settingsWindow)
             settingsWindow.contentViewController?.view.wantsLayer = true
-            settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
+            settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.background.cgColor
         }
 
         // Update agent dashboard appearance
@@ -838,6 +844,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 await TmuxThemeApplicator.apply(themeInfo: themeInfo, tmuxBackend: tmuxBackend)
             }
         }
+    }
+
+    private func refreshGhosttyThemeBackgrounds(themeInfo: GhosttyThemeInfo) {
+        sidebarController?.updateAppearance(themeInfo: themeInfo)
+        terminalAreaController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
     }
 
     // MARK: - Proxy

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -28,6 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var settingsWindowController: NSWindowController?
     private var configFile: GhosttyConfigFile?
     private var proxyApplyTask: Task<Void, Never>?
+    private var tmuxThemeApplyTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
     private var remoteConnectWizardController: RemoteConnectWizardController?
     private var updateController: UpdateController?
@@ -277,11 +278,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             await ProxySettingsApplicator.apply(model, tmuxBackend: tmuxBackend)
 
             // Apply theme (including status bar off) to the newly created session
-            if let terminalArea = self?.terminalAreaController {
-                await TmuxThemeApplicator.apply(
-                    themeInfo: terminalArea.themeInfo,
-                    tmuxBackend: tmuxBackend
-                )
+            if let self {
+                self.scheduleTmuxThemeApply(immediate: true, tmuxBackend: tmuxBackend)
             }
         }
 
@@ -332,12 +330,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             manager.startPolling()
 
             // Apply ghostty theme colors to tmux (pane borders, status bar)
-            if let terminalArea = self.terminalAreaController {
-                await TmuxThemeApplicator.apply(
-                    themeInfo: terminalArea.themeInfo,
-                    tmuxBackend: manager.tmuxBackend
-                )
-            }
+            self.scheduleTmuxThemeApply(immediate: true, tmuxBackend: manager.tmuxBackend)
 
             // Apply proxy environment variables to tmux
             self.applyProxyToTmux()
@@ -842,9 +835,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Sync to tmux
         if let tmuxBackend = workspaceManager?.tmuxBackend {
-            Task {
-                await TmuxThemeApplicator.apply(themeInfo: themeInfo, tmuxBackend: tmuxBackend)
+            scheduleTmuxThemeApply(immediate: false, tmuxBackend: tmuxBackend)
+        }
+    }
+
+    private func scheduleTmuxThemeApply(immediate: Bool, tmuxBackend: TmuxBackend) {
+        tmuxThemeApplyTask?.cancel()
+        let delayNanoseconds: UInt64 = immediate ? 0 : 250_000_000
+        tmuxThemeApplyTask = Task { [weak self] in
+            if delayNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: delayNanoseconds)
             }
+            guard !Task.isCancelled,
+                  let themeInfo = self?.terminalAreaController?.themeInfo else { return }
+            await TmuxThemeApplicator.apply(themeInfo: themeInfo, tmuxBackend: tmuxBackend)
         }
     }
 

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -36,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var keyBindingStore: KeyBindingStore!
     private var configurableMenuItems: [String: NSMenuItem] = [:]
     private var keyMonitorActionMap: [String: () -> Void] = [:]
+    private let tmuxThemeDebounceNanoseconds: UInt64 = 250_000_000
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Task 3.8: Single instance check
@@ -823,12 +824,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         refreshGhosttyThemeBackgrounds(themeInfo: themeInfo)
 
-        // Update settings window appearance
-        if let settingsWindow = settingsWindowController?.window {
-            adapter.syncThemedWindowAppearance(settingsWindow)
-            settingsWindow.contentViewController?.view.wantsLayer = true
-            settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.background.cgColor
-        }
+        refreshSettingsWindowAppearance(adapter: adapter, themeInfo: themeInfo)
 
         // Update agent dashboard appearance
         agentDashboardPanel?.updateAppearance(themeInfo: themeInfo)
@@ -841,7 +837,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func scheduleTmuxThemeApply(immediate: Bool, tmuxBackend: TmuxBackend) {
         tmuxThemeApplyTask?.cancel()
-        let delayNanoseconds: UInt64 = immediate ? 0 : 250_000_000
+        let delayNanoseconds = immediate ? 0 : tmuxThemeDebounceNanoseconds
         tmuxThemeApplyTask = Task { [weak self] in
             if delayNanoseconds > 0 {
                 try? await Task.sleep(nanoseconds: delayNanoseconds)
@@ -858,6 +854,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             themeInfo: themeInfo,
             isKeyWindow: mainWindowController?.window?.isKeyWindow ?? true
         )
+    }
+
+    private func refreshSettingsWindowAppearance(adapter: GhosttyAdapter, themeInfo: GhosttyThemeInfo) {
+        guard let settingsWindow = settingsWindowController?.window else { return }
+        adapter.syncThemedWindowAppearance(settingsWindow)
+        settingsWindow.contentViewController?.view.wantsLayer = true
+        settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.background.cgColor
     }
 
     // MARK: - Proxy

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -109,6 +109,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Build the window with ghostty theme
         let windowController = MainWindowController(themeInfo: themeInfo)
         self.mainWindowController = windowController
+        if let adapter = terminalArea.terminalHost as? GhosttyAdapter,
+           let window = windowController.window {
+            adapter.syncWindowAppearance(window)
+        }
 
         // Build split view children
         let sidebarController = SidebarHostingController(
@@ -741,14 +745,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let hostingController = NSHostingController(rootView: settingsView)
         hostingController.view.wantsLayer = true
-        hostingController.view.layer?.backgroundColor = themeInfo.background.cgColor
+        hostingController.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
         let window = NSWindow(contentViewController: hostingController)
         window.title = .localized("Settings")
         window.styleMask = [.titled, .closable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        window.backgroundColor = themeInfo.background
-        window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+        if let adapter = terminalAreaController?.terminalHost as? GhosttyAdapter {
+            adapter.syncWindowAppearance(window)
+        } else {
+            window.backgroundColor = themeInfo.background
+            window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+        }
         window.center()
         window.setFrameAutosaveName("MoriSettings")
 
@@ -765,6 +773,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             cursorStyle: cf.get("cursor-style") ?? "block",
             cursorBlink: (cf.get("cursor-style-blink") ?? "true") != "false",
             backgroundOpacity: Double(cf.get("background-opacity") ?? "1.0") ?? 1.0,
+            backgroundBlur: GhosttyBackgroundBlur(configValue: cf.get("background-blur") ?? "false"),
             macosOptionAsAlt: cf.get("macos-option-as-alt") ?? "false",
             mouseHideWhileTyping: cf.get("mouse-hide-while-typing") == "true",
             mouseScrollMultiplier: Int(cf.get("mouse-scroll-multiplier") ?? "") ?? 1,
@@ -793,6 +802,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         cf.set("cursor-style", value: model.cursorStyle)
         cf.set("cursor-style-blink", value: model.cursorBlink ? "true" : "false")
         cf.set("background-opacity", value: String(format: "%.2f", model.backgroundOpacity))
+        cf.set("background-blur", value: model.backgroundBlur.configValue)
         cf.set("macos-option-as-alt", value: model.macosOptionAsAlt)
         cf.set("mouse-hide-while-typing", value: model.mouseHideWhileTyping ? "true" : "false")
         cf.set("mouse-scroll-multiplier", value: "\(model.mouseScrollMultiplier)")
@@ -806,17 +816,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         adapter.reloadConfig()
 
         let themeInfo = adapter.themeInfo
-        mainWindowController?.window?.backgroundColor = themeInfo.background
-        mainWindowController?.window?.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+        if let window = mainWindowController?.window {
+            adapter.syncWindowAppearance(window)
+        }
         sidebarController?.updateAppearance(themeInfo: themeInfo)
-        terminalAreaController?.view.layer?.backgroundColor = themeInfo.background.cgColor
+        terminalAreaController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
 
         // Update settings window appearance
         if let settingsWindow = settingsWindowController?.window {
-            settingsWindow.backgroundColor = themeInfo.background
-            settingsWindow.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+            adapter.syncWindowAppearance(settingsWindow)
             settingsWindow.contentViewController?.view.wantsLayer = true
-            settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.background.cgColor
+            settingsWindow.contentViewController?.view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
         }
 
         // Update agent dashboard appearance

--- a/Sources/Mori/App/HostingControllers.swift
+++ b/Sources/Mori/App/HostingControllers.swift
@@ -70,7 +70,7 @@ final class SidebarHostingController: NSHostingController<SidebarContentView> {
     /// Sync the hosting controller's view appearance with the ghostty theme.
     func updateAppearance(themeInfo: GhosttyThemeInfo) {
         view.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
-        view.layer?.backgroundColor = themeInfo.background.cgColor
+        view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
         // Force SwiftUI to re-render with the updated appearance context.
         view.needsDisplay = true
     }

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -122,6 +122,14 @@ extension MainWindowController: NSWindowDelegate {
     func windowDidExitFullScreen(_ notification: Notification) {
         onWindowAppearanceInvalidated?()
     }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        onWindowAppearanceInvalidated?()
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        onWindowAppearanceInvalidated?()
+    }
 }
 
 extension MainWindowController: NSToolbarDelegate {

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -30,7 +30,7 @@ final class MainWindowController: NSWindowController {
         window.title = "Mori"
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
-        window.backgroundColor = themeInfo.background
+        window.backgroundColor = themeInfo.effectiveBackground
         window.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
         window.center()
 

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import MoriTerminal
 
 final class MainWindowController: NSWindowController {
+    var onWindowAppearanceInvalidated: (() -> Void)?
 
     // MARK: - Toolbar
 
@@ -36,6 +37,7 @@ final class MainWindowController: NSWindowController {
 
         super.init(window: window)
 
+        window.delegate = self
         configureToolbar()
     }
 
@@ -111,6 +113,16 @@ final class MainWindowController: NSWindowController {
 }
 
 // MARK: - NSToolbarDelegate
+
+extension MainWindowController: NSWindowDelegate {
+    func windowDidEnterFullScreen(_ notification: Notification) {
+        onWindowAppearanceInvalidated?()
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        onWindowAppearanceInvalidated?()
+    }
+}
 
 extension MainWindowController: NSToolbarDelegate {
 

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -3,12 +3,78 @@ import MoriCore
 import MoriTerminal
 import MoriTmux
 
+#if compiler(>=6.2)
+@available(macOS 26.0, *)
+private final class WorkspaceGlassBackgroundView: NSView {
+    private let glassEffectView = NSGlassEffectView()
+    private let tintOverlay = NSView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        glassEffectView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(glassEffectView)
+        NSLayoutConstraint.activate([
+            glassEffectView.topAnchor.constraint(equalTo: topAnchor),
+            glassEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            glassEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            glassEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        tintOverlay.translatesAutoresizingMaskIntoConstraints = false
+        tintOverlay.wantsLayer = true
+        tintOverlay.alphaValue = 0
+        addSubview(tintOverlay, positioned: .above, relativeTo: glassEffectView)
+        NSLayoutConstraint.activate([
+            tintOverlay.topAnchor.constraint(equalTo: topAnchor),
+            tintOverlay.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tintOverlay.bottomAnchor.constraint(equalTo: bottomAnchor),
+            tintOverlay.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        style: NSGlassEffectView.Style,
+        backgroundColor: NSColor,
+        backgroundOpacity: Double,
+        isKeyWindow: Bool
+    ) {
+        glassEffectView.style = style
+        glassEffectView.tintColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        updateKeyStatus(isKeyWindow, backgroundColor: backgroundColor)
+    }
+
+    func updateKeyStatus(_ isKeyWindow: Bool, backgroundColor: NSColor) {
+        let tint = tintProperties(for: backgroundColor)
+        tintOverlay.layer?.backgroundColor = tint.color.cgColor
+        tintOverlay.alphaValue = isKeyWindow ? 0 : tint.opacity
+    }
+
+    private func tintProperties(for color: NSColor) -> (color: NSColor, opacity: CGFloat) {
+        let srgb = color.usingColorSpace(.sRGB) ?? color
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
+        srgb.getRed(&r, green: &g, blue: &b, alpha: nil)
+        let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        let isLight = luminance >= 0.5
+        let overlayOpacity: CGFloat = isLight ? 0.35 : 0.85
+        return (srgb, overlayOpacity)
+    }
+}
+#endif
+
 /// View controller that hosts terminal surfaces, one per tmux session.
 /// Uses a TerminalSurfaceCache to manage an LRU pool of surfaces (max 3).
 /// When a worktree is selected, it shows the corresponding terminal surface
 /// running `tmux new-session -A -s <session-name>` to attach-or-create.
 @MainActor
 final class TerminalAreaViewController: NSViewController {
+    private var glassBackgroundView: NSView?
 
     // MARK: - Dependencies
 
@@ -62,8 +128,8 @@ final class TerminalAreaViewController: NSViewController {
     override func loadView() {
         let container = NSView()
         container.wantsLayer = true
-        container.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
         self.view = container
+        updateAppearance(themeInfo: themeInfo, isKeyWindow: true)
         showEmptyState()
     }
 
@@ -73,6 +139,63 @@ final class TerminalAreaViewController: NSViewController {
         if let surface = currentSurface {
             terminalHost.surfaceDidResize(surface, to: view.bounds.size)
         }
+    }
+
+    func updateAppearance(themeInfo: GhosttyThemeInfo, isKeyWindow: Bool) {
+        view.layer?.backgroundColor = backgroundColor(for: themeInfo).cgColor
+        updateGlassEffectIfNeeded(themeInfo: themeInfo, isKeyWindow: isKeyWindow)
+    }
+
+    private func backgroundColor(for themeInfo: GhosttyThemeInfo) -> NSColor {
+        themeInfo.backgroundBlur.isGlassStyle ? .clear : themeInfo.effectiveBackground
+    }
+
+#if compiler(>=6.2)
+    @available(macOS 26.0, *)
+    private func makeGlassBackgroundView() -> WorkspaceGlassBackgroundView {
+        if let glassBackgroundView = glassBackgroundView as? WorkspaceGlassBackgroundView {
+            return glassBackgroundView
+        }
+
+        let glassBackgroundView = WorkspaceGlassBackgroundView()
+        glassBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(glassBackgroundView, positioned: .below, relativeTo: nil)
+        NSLayoutConstraint.activate([
+            glassBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            glassBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            glassBackgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            glassBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+        self.glassBackgroundView = glassBackgroundView
+        return glassBackgroundView
+    }
+#endif
+
+    private func updateGlassEffectIfNeeded(themeInfo: GhosttyThemeInfo, isKeyWindow: Bool) {
+#if compiler(>=6.2)
+        guard #available(macOS 26.0, *), themeInfo.backgroundBlur.isGlassStyle else {
+            glassBackgroundView?.removeFromSuperview()
+            glassBackgroundView = nil
+            return
+        }
+
+        let style: NSGlassEffectView.Style = switch themeInfo.backgroundBlur {
+        case .macosGlassRegular:
+            .regular
+        case .macosGlassClear:
+            .clear
+        default:
+            .regular
+        }
+
+        let glassBackgroundView = makeGlassBackgroundView()
+        glassBackgroundView.configure(
+            style: style,
+            backgroundColor: themeInfo.background,
+            backgroundOpacity: themeInfo.backgroundOpacity,
+            isKeyWindow: isKeyWindow
+        )
+#endif
     }
 
     // MARK: - Public API

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -62,7 +62,7 @@ final class TerminalAreaViewController: NSViewController {
     override func loadView() {
         let container = NSView()
         container.wantsLayer = true
-        container.layer?.backgroundColor = themeInfo.background.cgColor
+        container.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
         self.view = container
         showEmptyState()
     }

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -173,19 +173,10 @@ final class TerminalAreaViewController: NSViewController {
 
     private func updateGlassEffectIfNeeded(themeInfo: GhosttyThemeInfo, isKeyWindow: Bool) {
 #if compiler(>=6.2)
-        guard #available(macOS 26.0, *), themeInfo.backgroundBlur.isGlassStyle else {
+        guard #available(macOS 26.0, *), let style = glassStyle(for: themeInfo) else {
             glassBackgroundView?.removeFromSuperview()
             glassBackgroundView = nil
             return
-        }
-
-        let style: NSGlassEffectView.Style = switch themeInfo.backgroundBlur {
-        case .macosGlassRegular:
-            .regular
-        case .macosGlassClear:
-            .clear
-        default:
-            .regular
         }
 
         let glassBackgroundView = makeGlassBackgroundView()
@@ -197,6 +188,20 @@ final class TerminalAreaViewController: NSViewController {
         )
 #endif
     }
+
+#if compiler(>=6.2)
+    @available(macOS 26.0, *)
+    private func glassStyle(for themeInfo: GhosttyThemeInfo) -> NSGlassEffectView.Style? {
+        switch themeInfo.backgroundBlur {
+        case .macosGlassRegular:
+            .regular
+        case .macosGlassClear:
+            .clear
+        default:
+            nil
+        }
+    }
+#endif
 
     // MARK: - Public API
 

--- a/Sources/Mori/App/TmuxThemeApplicator.swift
+++ b/Sources/Mori/App/TmuxThemeApplicator.swift
@@ -20,14 +20,14 @@ enum TmuxThemeApplicator {
     }
 
     private actor Cache {
-        private var lastAppliedPayload: ThemePayload?
+        private var lastAppliedPayloads: [ObjectIdentifier: ThemePayload] = [:]
 
-        func shouldApply(_ payload: ThemePayload) -> Bool {
-            payload != lastAppliedPayload
+        func shouldApply(_ payload: ThemePayload, backendID: ObjectIdentifier) -> Bool {
+            payload != lastAppliedPayloads[backendID]
         }
 
-        func markApplied(_ payload: ThemePayload) {
-            lastAppliedPayload = payload
+        func markApplied(_ payload: ThemePayload, backendID: ObjectIdentifier) {
+            lastAppliedPayloads[backendID] = payload
         }
     }
 
@@ -35,7 +35,8 @@ enum TmuxThemeApplicator {
 
     static func apply(themeInfo: GhosttyThemeInfo, tmuxBackend: TmuxBackend) async {
         let payload = makePayload(themeInfo: themeInfo)
-        guard await cache.shouldApply(payload) else { return }
+        let backendID = ObjectIdentifier(tmuxBackend)
+        guard await cache.shouldApply(payload, backendID: backendID) else { return }
 
         let styles = makeStyles(payload: payload)
         await applyGlobalCompatibilityOptions(tmuxBackend: tmuxBackend)
@@ -47,7 +48,7 @@ enum TmuxThemeApplicator {
 
         do {
             try await tmuxBackend.refreshClients()
-            await cache.markApplied(payload)
+            await cache.markApplied(payload, backendID: backendID)
         } catch {
             print("[TmuxThemeApplicator] Failed to refresh clients: \(error)")
         }

--- a/Sources/Mori/App/TmuxThemeApplicator.swift
+++ b/Sources/Mori/App/TmuxThemeApplicator.swift
@@ -12,7 +12,8 @@ enum TmuxThemeApplicator {
         let fg = GhosttyThemeInfo.hexString(themeInfo.foreground)
         let bg = GhosttyThemeInfo.hexString(themeInfo.background)
 
-        let windowStyle = "fg=\(fg),bg=\(bg)"
+        let defaultBackedWindowStyle = themeInfo.backgroundOpacity < 1 && !themeInfo.backgroundOpacityCells
+        let windowStyle = defaultBackedWindowStyle ? "fg=\(fg),bg=default" : "fg=\(fg),bg=\(bg)"
         let borderFg = themeInfo.palette.count > 8
             ? GhosttyThemeInfo.hexString(themeInfo.palette[8])  // bright black
             : fg
@@ -24,11 +25,12 @@ enum TmuxThemeApplicator {
             : bg
 
         // Session-level options (set-option -g)
+        let statusStyle = defaultBackedWindowStyle ? "fg=\(fg),bg=default" : "fg=\(fg),bg=\(statusBg)"
         let sessionOptions: [(String, String)] = [
             ("mouse", "on"),
             ("status", "off"),
-            ("status-style", "fg=\(fg),bg=\(statusBg)"),
-            ("message-style", "fg=\(fg),bg=\(statusBg)"),
+            ("status-style", statusStyle),
+            ("message-style", statusStyle),
             ("allow-passthrough", "on"),
         ]
 

--- a/Sources/Mori/App/TmuxThemeApplicator.swift
+++ b/Sources/Mori/App/TmuxThemeApplicator.swift
@@ -10,9 +10,13 @@ enum TmuxThemeApplicator {
     private struct ThemePayload: Equatable {
         let foreground: String
         let background: String
-        let backgroundOpacity: Double
-        let backgroundOpacityCells: Bool
+        let prefersDefaultBackgrounds: Bool
         let palette: [String]
+    }
+
+    private struct ThemeStyles {
+        let sessionOptions: [(String, String)]
+        let windowOptions: [(String, String)]
     }
 
     private actor Cache {
@@ -30,117 +34,117 @@ enum TmuxThemeApplicator {
     private static let cache = Cache()
 
     static func apply(themeInfo: GhosttyThemeInfo, tmuxBackend: TmuxBackend) async {
-        let payload = ThemePayload(
-            foreground: GhosttyThemeInfo.hexString(themeInfo.foreground),
-            background: GhosttyThemeInfo.hexString(themeInfo.background),
-            backgroundOpacity: themeInfo.backgroundOpacity,
-            backgroundOpacityCells: themeInfo.backgroundOpacityCells,
-            palette: themeInfo.palette.map(GhosttyThemeInfo.hexString)
-        )
+        let payload = makePayload(themeInfo: themeInfo)
         guard await cache.shouldApply(payload) else { return }
-        let fg = payload.foreground
-        let bg = payload.background
 
-        let defaultBackedWindowStyle = themeInfo.backgroundOpacity < 1 && !themeInfo.backgroundOpacityCells
-        let windowStyle = defaultBackedWindowStyle ? "fg=\(fg),bg=default" : "fg=\(fg),bg=\(bg)"
-        let borderFg = payload.palette.count > 8
-            ? payload.palette[8]  // bright black
-            : fg
-        let activeBorderFg = payload.palette.count > 4
-            ? payload.palette[4]  // blue
-            : fg
-        let statusBg = payload.palette.count > 0
-            ? payload.palette[0]  // palette black
-            : bg
-
-        // Session-level options (set-option -g)
-        let statusStyle = defaultBackedWindowStyle ? "fg=\(fg),bg=default" : "fg=\(fg),bg=\(statusBg)"
-        let sessionOptions: [(String, String)] = [
-            ("mouse", "on"),
-            ("status", "off"),
-            ("status-style", statusStyle),
-            ("message-style", statusStyle),
-            ("allow-passthrough", "on"),
-        ]
-
-        // Window-level options (set-option -gw)
-        let windowOptions: [(String, String)] = [
-            ("window-style", windowStyle),
-            ("window-active-style", windowStyle),
-            ("pane-border-style", "fg=\(borderFg)"),
-            ("pane-active-border-style", "fg=\(activeBorderFg)"),
-        ]
-
-        // Global compatibility for image protocols in tmux (affects all sessions,
-        // including non-Mori sessions attached from remote hosts).
-        try? await tmuxBackend.setOption(sessionId: nil, option: "allow-passthrough", value: "on")
-        let globalUpdateEnv = (try? await tmuxBackend.optionValues(
-            sessionId: nil,
-            option: "update-environment"
-        )) ?? []
-        if !globalUpdateEnv.contains("TERM") {
-            try? await tmuxBackend.appendOptionValue(
-                sessionId: nil,
-                option: "update-environment",
-                value: "TERM"
-            )
-        }
-        if !globalUpdateEnv.contains("TERM_PROGRAM") {
-            try? await tmuxBackend.appendOptionValue(
-                sessionId: nil,
-                option: "update-environment",
-                value: "TERM_PROGRAM"
-            )
-        }
-
-        // Apply only to Mori-managed sessions (those matching <project>/<branch> naming).
-        // Non-Mori sessions are left untouched so they inherit the user's tmux.conf.
-        do {
-            let sessions = try await tmuxBackend.scanAll()
-            for session in sessions where session.isMoriSession {
-                for (option, value) in sessionOptions {
-                    try? await tmuxBackend.setOption(sessionId: session.id, option: option, value: value)
-                }
-
-                // Yazi image preview in tmux requires TERM/TERM_PROGRAM to be
-                // propagated from the attached client environment.
-                let updateEnv = (try? await tmuxBackend.optionValues(
-                    sessionId: session.id,
-                    option: "update-environment"
-                )) ?? []
-                if !updateEnv.contains("TERM") {
-                    try? await tmuxBackend.appendOptionValue(
-                        sessionId: session.id,
-                        option: "update-environment",
-                        value: "TERM"
-                    )
-                }
-                if !updateEnv.contains("TERM_PROGRAM") {
-                    try? await tmuxBackend.appendOptionValue(
-                        sessionId: session.id,
-                        option: "update-environment",
-                        value: "TERM_PROGRAM"
-                    )
-                }
-
-                for (option, value) in windowOptions {
-                    try? await tmuxBackend.setWindowOption(global: false, target: session.id, option: option, value: value)
-                }
-            }
-        } catch {
-            print("[TmuxThemeApplicator] Failed to list sessions for per-session theme: \(error)")
-        }
+        let styles = makeStyles(payload: payload)
+        await applyGlobalCompatibilityOptions(tmuxBackend: tmuxBackend)
+        await applySessionThemes(styles: styles, tmuxBackend: tmuxBackend)
 
         // Help terminal-aware apps (e.g. Yazi) detect Ghostty capabilities,
         // especially across SSH+tmux where TERM_PROGRAM may be missing.
         try? await tmuxBackend.setEnvironment(name: "TERM_PROGRAM", value: "ghostty")
 
-        // Force all attached clients to redraw
         do {
             try await tmuxBackend.refreshClients()
             await cache.markApplied(payload)
         } catch {
             print("[TmuxThemeApplicator] Failed to refresh clients: \(error)")
         }
+    }
+
+    private static func makePayload(themeInfo: GhosttyThemeInfo) -> ThemePayload {
+        ThemePayload(
+            foreground: GhosttyThemeInfo.hexString(themeInfo.foreground),
+            background: GhosttyThemeInfo.hexString(themeInfo.background),
+            prefersDefaultBackgrounds: themeInfo.backgroundOpacity < 1 && !themeInfo.backgroundOpacityCells,
+            palette: themeInfo.palette.map(GhosttyThemeInfo.hexString)
+        )
+    }
+
+    private static func makeStyles(payload: ThemePayload) -> ThemeStyles {
+        let fg = payload.foreground
+        let bg = payload.background
+        let windowBackground = payload.prefersDefaultBackgrounds ? "default" : bg
+        let statusBackground = payload.prefersDefaultBackgrounds
+            ? "default"
+            : paletteColor(payload.palette, index: 0, fallback: bg)
+        let borderFg = paletteColor(payload.palette, index: 8, fallback: fg)
+        let activeBorderFg = paletteColor(payload.palette, index: 4, fallback: fg)
+
+        let sessionOptions: [(String, String)] = [
+            ("mouse", "on"),
+            ("status", "off"),
+            ("status-style", "fg=\(fg),bg=\(statusBackground)"),
+            ("message-style", "fg=\(fg),bg=\(statusBackground)"),
+            ("allow-passthrough", "on"),
+        ]
+
+        let windowOptions: [(String, String)] = [
+            ("window-style", "fg=\(fg),bg=\(windowBackground)"),
+            ("window-active-style", "fg=\(fg),bg=\(windowBackground)"),
+            ("pane-border-style", "fg=\(borderFg)"),
+            ("pane-active-border-style", "fg=\(activeBorderFg)"),
+        ]
+
+        return ThemeStyles(sessionOptions: sessionOptions, windowOptions: windowOptions)
+    }
+
+    private static func applyGlobalCompatibilityOptions(tmuxBackend: TmuxBackend) async {
+        // Global compatibility for image protocols in tmux (affects all sessions,
+        // including non-Mori sessions attached from remote hosts).
+        try? await tmuxBackend.setOption(sessionId: nil, option: "allow-passthrough", value: "on")
+        await ensureUpdateEnvironment(sessionId: nil, tmuxBackend: tmuxBackend)
+    }
+
+    private static func applySessionThemes(styles: ThemeStyles, tmuxBackend: TmuxBackend) async {
+        // Apply only to Mori-managed sessions (those matching <project>/<branch> naming).
+        // Non-Mori sessions are left untouched so they inherit the user's tmux.conf.
+        do {
+            let sessions = try await tmuxBackend.scanAll()
+            for session in sessions where session.isMoriSession {
+                for (option, value) in styles.sessionOptions {
+                    try? await tmuxBackend.setOption(sessionId: session.id, option: option, value: value)
+                }
+
+                await ensureUpdateEnvironment(sessionId: session.id, tmuxBackend: tmuxBackend)
+
+                for (option, value) in styles.windowOptions {
+                    try? await tmuxBackend.setWindowOption(global: false, target: session.id, option: option, value: value)
+                }
+            }
+        } catch {
+            print("[TmuxThemeApplicator] Failed to list sessions for per-session theme: \(error)")
+        }
+    }
+
+    private static func ensureUpdateEnvironment(sessionId: String?, tmuxBackend: TmuxBackend) async {
+        // Yazi image preview in tmux requires TERM/TERM_PROGRAM to be
+        // propagated from the attached client environment.
+        let updateEnv = (try? await tmuxBackend.optionValues(
+            sessionId: sessionId,
+            option: "update-environment"
+        )) ?? []
+
+        if !updateEnv.contains("TERM") {
+            try? await tmuxBackend.appendOptionValue(
+                sessionId: sessionId,
+                option: "update-environment",
+                value: "TERM"
+            )
+        }
+
+        if !updateEnv.contains("TERM_PROGRAM") {
+            try? await tmuxBackend.appendOptionValue(
+                sessionId: sessionId,
+                option: "update-environment",
+                value: "TERM_PROGRAM"
+            )
+        }
+    }
+
+    private static func paletteColor(_ palette: [String], index: Int, fallback: String) -> String {
+        guard palette.indices.contains(index) else { return fallback }
+        return palette[index]
     }
 }

--- a/Sources/Mori/App/TmuxThemeApplicator.swift
+++ b/Sources/Mori/App/TmuxThemeApplicator.swift
@@ -7,21 +7,50 @@ import MoriTmux
 /// Reads resolved colors from GhosttyThemeInfo (extracted from ghostty's config)
 /// and sets both global defaults (for new sessions) and per-session overrides.
 enum TmuxThemeApplicator {
+    private struct ThemePayload: Equatable {
+        let foreground: String
+        let background: String
+        let backgroundOpacity: Double
+        let backgroundOpacityCells: Bool
+        let palette: [String]
+    }
+
+    private actor Cache {
+        private var lastAppliedPayload: ThemePayload?
+
+        func shouldApply(_ payload: ThemePayload) -> Bool {
+            payload != lastAppliedPayload
+        }
+
+        func markApplied(_ payload: ThemePayload) {
+            lastAppliedPayload = payload
+        }
+    }
+
+    private static let cache = Cache()
 
     static func apply(themeInfo: GhosttyThemeInfo, tmuxBackend: TmuxBackend) async {
-        let fg = GhosttyThemeInfo.hexString(themeInfo.foreground)
-        let bg = GhosttyThemeInfo.hexString(themeInfo.background)
+        let payload = ThemePayload(
+            foreground: GhosttyThemeInfo.hexString(themeInfo.foreground),
+            background: GhosttyThemeInfo.hexString(themeInfo.background),
+            backgroundOpacity: themeInfo.backgroundOpacity,
+            backgroundOpacityCells: themeInfo.backgroundOpacityCells,
+            palette: themeInfo.palette.map(GhosttyThemeInfo.hexString)
+        )
+        guard await cache.shouldApply(payload) else { return }
+        let fg = payload.foreground
+        let bg = payload.background
 
         let defaultBackedWindowStyle = themeInfo.backgroundOpacity < 1 && !themeInfo.backgroundOpacityCells
         let windowStyle = defaultBackedWindowStyle ? "fg=\(fg),bg=default" : "fg=\(fg),bg=\(bg)"
-        let borderFg = themeInfo.palette.count > 8
-            ? GhosttyThemeInfo.hexString(themeInfo.palette[8])  // bright black
+        let borderFg = payload.palette.count > 8
+            ? payload.palette[8]  // bright black
             : fg
-        let activeBorderFg = themeInfo.palette.count > 4
-            ? GhosttyThemeInfo.hexString(themeInfo.palette[4])  // blue
+        let activeBorderFg = payload.palette.count > 4
+            ? payload.palette[4]  // blue
             : fg
-        let statusBg = themeInfo.palette.count > 0
-            ? GhosttyThemeInfo.hexString(themeInfo.palette[0])  // palette black
+        let statusBg = payload.palette.count > 0
+            ? payload.palette[0]  // palette black
             : bg
 
         // Session-level options (set-option -g)
@@ -109,6 +138,7 @@ enum TmuxThemeApplicator {
         // Force all attached clients to redraw
         do {
             try await tmuxBackend.refreshClients()
+            await cache.markApplied(payload)
         } catch {
             print("[TmuxThemeApplicator] Failed to refresh clients: \(error)")
         }

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -78,11 +78,6 @@
 "Redo" = "Redo";
 "Refresh" = "Refresh";
 "Reload Settings" = "Reload Settings";
-"Background blur" = "Background blur";
-"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.";
-"Background blur is only visible when background opacity is below 1.0." = "Background blur is only visible when background opacity is below 1.0.";
-"Apply opacity to colored cells" = "Apply opacity to colored cells";
-"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background.";
 "Standard Blur" = "Standard Blur";
 "Custom Blur Radius" = "Custom Blur Radius";
 "Glass Regular" = "Glass Regular";

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Open Lazygit" = "Open Lazygit";
 "Open Project" = "Open Project";
 "Open Project…" = "Open Project…";
+"Off" = "Off";
 "Open Yazi" = "Open Yazi";
 "Paste" = "Paste";
 "Path:" = "Path:";
@@ -77,6 +78,12 @@
 "Redo" = "Redo";
 "Refresh" = "Refresh";
 "Reload Settings" = "Reload Settings";
+"Background blur" = "Background blur";
+"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.";
+"Standard Blur" = "Standard Blur";
+"Custom Blur Radius" = "Custom Blur Radius";
+"Glass Regular" = "Glass Regular";
+"Glass Clear" = "Glass Clear";
 "Remove" = "Remove";
 "Remove from Mori" = "Remove from Mori";
 "Remove from Mori and Delete Files" = "Remove from Mori and Delete Files";

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "Background blur" = "Background blur";
 "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.";
 "Background blur is only visible when background opacity is below 1.0." = "Background blur is only visible when background opacity is below 1.0.";
+"Apply opacity to colored cells" = "Apply opacity to colored cells";
+"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background.";
 "Standard Blur" = "Standard Blur";
 "Custom Blur Radius" = "Custom Blur Radius";
 "Glass Regular" = "Glass Regular";

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -80,6 +80,7 @@
 "Reload Settings" = "Reload Settings";
 "Background blur" = "Background blur";
 "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds.";
+"Background blur is only visible when background opacity is below 1.0." = "Background blur is only visible when background opacity is below 1.0.";
 "Standard Blur" = "Standard Blur";
 "Custom Blur Radius" = "Custom Blur Radius";
 "Glass Regular" = "Glass Regular";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Open Lazygit" = "打开 Lazygit";
 "Open Project" = "打开项目";
 "Open Project..." = "打开项目...";
+"Off" = "关闭";
 "Open Yazi" = "打开 Yazi";
 "Paste" = "粘贴";
 "Path:" = "路径:";
@@ -77,6 +78,12 @@
 "Redo" = "重做";
 "Refresh" = "刷新";
 "Reload Settings" = "重新加载设置";
+"Background blur" = "背景模糊";
+"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "为半透明终端背景继承 Ghostty 的窗口模糊与玻璃效果样式。";
+"Standard Blur" = "标准模糊";
+"Custom Blur Radius" = "自定义模糊半径";
+"Glass Regular" = "常规玻璃";
+"Glass Clear" = "通透玻璃";
 "Remove" = "移除";
 "Remove from Mori" = "从 Mori 移除";
 "Remove from Mori and Delete Files" = "从 Mori 移除并删除文件";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "Background blur" = "背景模糊";
 "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "为半透明终端背景继承 Ghostty 的窗口模糊与玻璃效果样式。";
 "Background blur is only visible when background opacity is below 1.0." = "仅当背景不透明度低于 1.0 时，背景模糊才会可见。";
+"Apply opacity to colored cells" = "将不透明度应用到彩色单元格";
+"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "当 tmux 或终端应用绘制彩色单元格而不是使用默认终端背景时，也让这些背景保持半透明。";
 "Standard Blur" = "标准模糊";
 "Custom Blur Radius" = "自定义模糊半径";
 "Glass Regular" = "常规玻璃";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -78,11 +78,6 @@
 "Redo" = "重做";
 "Refresh" = "刷新";
 "Reload Settings" = "重新加载设置";
-"Background blur" = "背景模糊";
-"Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "为半透明终端背景继承 Ghostty 的窗口模糊与玻璃效果样式。";
-"Background blur is only visible when background opacity is below 1.0." = "仅当背景不透明度低于 1.0 时，背景模糊才会可见。";
-"Apply opacity to colored cells" = "将不透明度应用到彩色单元格";
-"Let tmux and terminal apps keep translucent backgrounds when they draw colored cells instead of using the default terminal background." = "当 tmux 或终端应用绘制彩色单元格而不是使用默认终端背景时，也让这些背景保持半透明。";
 "Standard Blur" = "标准模糊";
 "Custom Blur Radius" = "自定义模糊半径";
 "Glass Regular" = "常规玻璃";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -80,6 +80,7 @@
 "Reload Settings" = "重新加载设置";
 "Background blur" = "背景模糊";
 "Inherit Ghostty window blur and glass styling for translucent terminal backgrounds." = "为半透明终端背景继承 Ghostty 的窗口模糊与玻璃效果样式。";
+"Background blur is only visible when background opacity is below 1.0." = "仅当背景不透明度低于 1.0 时，背景模糊才会可见。";
 "Standard Blur" = "标准模糊";
 "Custom Blur Radius" = "自定义模糊半径";
 "Glass Regular" = "常规玻璃";


### PR DESCRIPTION
## Summary
- inherit Ghostty background opacity, blur, and cell-opacity settings in Mori
- apply Ghostty-style translucency/blur to the main workspace window and add macOS 26 glass polish for terminal content
- improve tmux translucency behavior and reduce sync latency with debounced, deduplicated theme updates

## Changes
- extend `GhosttyThemeInfo` with `background-opacity`, `background-opacity-cells`, and `background-blur`
- expose blur and cell-opacity controls in Settings and persist them back to Ghostty config
- align workspace window translucency behavior with Ghostty lifecycle rules, including fullscreen/key-window refreshes
- add a dedicated macOS 26 `NSGlassEffectView` background for terminal content when Ghostty glass styles are selected
- make tmux avoid forcing opaque backgrounds when cell opacity is disabled
- debounce and dedupe tmux theme sync work to make updates feel faster

## Verification
- `swift build -c release --product Mori`
- `mise run test`

Closes #46.
