### PR TITLE
Add in-window companion pane for Files and Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ♻️ Changes
 
 - Remove legacy workflow-status and sidebar-mode code paths after the unified sidebar redesign, including the `mori status` CLI command and manual sidebar status controls
+- Start replacing Yazi/Lazygit's separate tmux-window flow with a shared in-window companion tool pane that reuses one right-side split for Files and Git
 
 ## [0.3.4] - 2026-04-12
 

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -17,6 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var workspaceManager: WorkspaceManager?
     private var appState: AppState?
     private var terminalAreaController: TerminalAreaViewController?
+    private var companionToolController: CompanionToolPaneController?
     private var commandPaletteController: CommandPaletteController?
     private var rootSplitVC: RootSplitViewController?
     private var keyMonitor: Any?
@@ -37,6 +38,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var configurableMenuItems: [String: NSMenuItem] = [:]
     private var keyMonitorActionMap: [String: () -> Void] = [:]
     private let tmuxThemeDebounceNanoseconds: UInt64 = 250_000_000
+    private var companionToolState = CompanionToolPaneState()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Task 3.8: Single instance check
@@ -84,7 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Load persisted state
         try? manager.loadAll()
 
-        // Create terminal area first — this initializes GhosttyApp and extracts theme
+        // Create terminal areas first — this initializes GhosttyApp and extracts theme.
         let terminalArea = TerminalAreaViewController()
         terminalArea.onCreateSession = { [weak self] in
             guard let self else { return }
@@ -96,6 +98,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         self.terminalAreaController = terminalArea
+
+        let companionTool = CompanionToolPaneController()
+        self.companionToolController = companionTool
 
         // Wire ghostty keybinding actions to Mori's tmux-based implementation.
         // Ghostty maps keys to intents (new_tab, close_tab, etc.); Mori provides
@@ -118,14 +123,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             onSelectProject: { [weak manager, weak self] projectId in
                 manager?.selectProject(projectId)
                 self?.updateWindowTitle()
+                self?.syncVisibleCompanionToolToSelection()
             },
             onSelectWorktree: { [weak manager, weak self] worktreeId in
                 manager?.selectWorktree(worktreeId)
                 self?.updateWindowTitle()
+                self?.syncVisibleCompanionToolToSelection()
             },
             onSelectWindow: { [weak manager, weak self] windowId in
                 manager?.selectWindow(windowId)
                 self?.updateWindowTitle()
+                self?.syncVisibleCompanionToolToSelection()
             },
             onShowCreatePanel: { [weak self] in
                 self?.showCreateWorktreePanel()
@@ -216,9 +224,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let splitVC = RootSplitViewController(
             sidebarController: sidebarController,
-            contentController: terminalArea
+            contentController: terminalArea,
+            companionController: companionTool
         )
         self.rootSplitVC = splitVC
+        companionToolState.width = splitVC.currentCompanionWidth
+        splitVC.onCompanionWidthChanged = { [weak self] width in
+            self?.companionToolState.width = width
+        }
+        splitVC.updateCompanionPane(state: companionToolState)
 
         windowController.onToggleSidebar = { [weak splitVC] in
             splitVC?.toggleSidebar()
@@ -241,6 +255,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            let window = windowController.window {
             adapter.syncWorkspaceWindowAppearance(window)
         }
+        companionTool.updateAppearance(themeInfo: themeInfo, isKeyWindow: windowController.window?.isKeyWindow ?? true)
         // Restore saved frame after all layout is complete
         windowController.restoreSavedFrame()
         NSApp.activate(ignoringOtherApps: true)
@@ -333,9 +348,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        // Save window frame and sidebar width before teardown
+        // Save window frame and split widths before teardown
         mainWindowController?.saveFrame()
         rootSplitVC?.saveSidebarWidth()
+        rootSplitVC?.saveCompanionWidth()
 
         // Remove key monitor
         if let monitor = keyMonitor {
@@ -843,11 +859,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func refreshGhosttyThemeBackgrounds(themeInfo: GhosttyThemeInfo) {
+        let isKeyWindow = mainWindowController?.window?.isKeyWindow ?? true
         sidebarController?.updateAppearance(themeInfo: themeInfo)
-        terminalAreaController?.updateAppearance(
-            themeInfo: themeInfo,
-            isKeyWindow: mainWindowController?.window?.isKeyWindow ?? true
-        )
+        terminalAreaController?.updateAppearance(themeInfo: themeInfo, isKeyWindow: isKeyWindow)
+        companionToolController?.updateAppearance(themeInfo: themeInfo, isKeyWindow: isKeyWindow)
     }
 
     private func refreshSettingsWindowAppearance(adapter: GhosttyAdapter, themeInfo: GhosttyThemeInfo) {
@@ -1239,14 +1254,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         agentDashboardPanel?.updateAppearance(themeInfo: themeInfo)
     }
 
+    private func toggleCompanionTool(_ tool: CompanionTool) {
+        guard let manager = workspaceManager,
+              let context = manager.companionToolLaunchContext() else {
+            NSSound.beep()
+            return
+        }
+
+        if companionToolState.activeTool == tool, companionToolState.isVisible {
+            if companionToolController?.isFocused(in: mainWindowController?.window) == true {
+                companionToolState.activeTool = nil
+                companionToolState.presentation = .closed
+                rootSplitVC?.updateCompanionPane(state: companionToolState)
+                terminalAreaController?.focusCurrentSurface()
+            } else {
+                companionToolController?.show(tool: tool, context: context)
+                rootSplitVC?.updateCompanionPane(state: companionToolState)
+            }
+            return
+        }
+
+        companionToolState.activeTool = tool
+        if companionToolState.presentation == .closed {
+            companionToolState.presentation = .docked
+        }
+
+        companionToolController?.show(tool: tool, context: context)
+        rootSplitVC?.updateCompanionPane(state: companionToolState)
+    }
+
+    private func syncVisibleCompanionToolToSelection() {
+        guard companionToolState.isVisible,
+              let tool = companionToolState.activeTool,
+              let manager = workspaceManager else {
+            return
+        }
+
+        guard let context = manager.companionToolLaunchContext() else {
+            companionToolState.activeTool = nil
+            companionToolState.presentation = .closed
+            rootSplitVC?.updateCompanionPane(state: companionToolState)
+            return
+        }
+
+        companionToolController?.show(tool: tool, context: context, focus: false)
+        rootSplitVC?.updateCompanionPane(state: companionToolState)
+    }
+
     @objc private func openLazygitMenuAction() {
-        guard let manager = workspaceManager else { return }
-        Task { @MainActor in await manager.openToolWindow(command: "lazygit") }
+        toggleCompanionTool(.lazygit)
     }
 
     @objc private func openYaziMenuAction() {
-        guard let manager = workspaceManager else { return }
-        Task { @MainActor in await manager.openToolWindow(command: "yazi") }
+        toggleCompanionTool(.yazi)
     }
 
     @objc private func splitRightMenuAction() {
@@ -1411,8 +1471,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             "panes.resizeRight": managerAction { await $0.resizePane(direction: .right) },
             "panes.equalize": managerAction { await $0.equalizePanes() },
             "panes.toggleZoom": managerAction { await $0.togglePaneZoom() },
-            "tools.lazygit": managerAction { await $0.openToolWindow(command: "lazygit") },
-            "tools.yazi": managerAction { await $0.openToolWindow(command: "yazi") },
+            "tools.lazygit": { [weak self] in self?.toggleCompanionTool(.lazygit) },
+            "tools.yazi": { [weak self] in self?.toggleCompanionTool(.yazi) },
             "window.toggleSidebar": { [weak self] in self?.rootSplitVC?.toggleSidebar() },
             "window.closeWindow": { [weak self] in self?.mainWindowController?.window?.close() },
             "settings.open": { [weak self] in self?.showSettingsWindow() },
@@ -1449,15 +1509,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case .project(let id, _):
             manager.selectProject(id)
             mainWindowController?.updateTitle(projectName: appState?.selectedProject?.name)
+            syncVisibleCompanionToolToSelection()
 
         case .worktree(let id, _, _, _):
             manager.selectWorktree(id)
+            syncVisibleCompanionToolToSelection()
 
         case .window(let id, _, _, _):
             manager.selectWindow(id)
+            syncVisibleCompanionToolToSelection()
 
         case .agent(let windowId, _, _, _):
             manager.selectWindow(windowId)
+            syncVisibleCompanionToolToSelection()
 
         case .action(let id, _, _):
             handlePaletteAction(id, manager: manager)

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -243,6 +243,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowController.onToggleGit = { [weak self] in
             self?.toggleCompanionTool(.lazygit)
         }
+        windowController.onSplitRight = { [weak self] in
+            self?.splitRightMenuAction()
+        }
+        windowController.onSplitDown = { [weak self] in
+            self?.splitDownMenuAction()
+        }
 
         windowController.onShowCreateWorktreePanel = { [weak self] in
             self?.showCreateWorktreePanel()

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -1273,25 +1273,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
 
-        if companionToolState.activeTool == tool, companionToolState.isVisible {
-            if companionToolController?.isFocused(in: mainWindowController?.window) == true {
-                companionToolState.activeTool = nil
-                companionToolState.presentation = .closed
-                rootSplitVC?.updateCompanionPane(state: companionToolState)
-                terminalAreaController?.focusCurrentSurface()
-            } else {
-                companionToolController?.show(tool: tool, context: context)
-                rootSplitVC?.updateCompanionPane(state: companionToolState)
-            }
+        let sameToolVisible = companionToolState.activeTool == tool && companionToolState.isVisible
+        let toolIsFocused = companionToolController?.isFocused(in: mainWindowController?.window) == true
+
+        if sameToolVisible && toolIsFocused {
+            closeCompanionTool()
+            terminalAreaController?.focusCurrentSurface()
             return
         }
 
-        companionToolState.activeTool = tool
-        if companionToolState.presentation == .closed {
-            companionToolState.presentation = .docked
-        }
+        showCompanionTool(tool, context: context)
+    }
 
-        companionToolController?.show(tool: tool, context: context)
+    private func closeCompanionTool() {
+        companionToolState.activeTool = nil
+        companionToolState.presentation = .closed
+        rootSplitVC?.updateCompanionPane(state: companionToolState)
+    }
+
+    private func showCompanionTool(_ tool: CompanionTool, context: CompanionToolLaunchContext, focus: Bool = true) {
+        companionToolState.activeTool = tool
+        companionToolState.presentation = .docked
+        companionToolController?.show(tool: tool, context: context, focus: focus)
         rootSplitVC?.updateCompanionPane(state: companionToolState)
     }
 
@@ -1303,14 +1306,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         guard let context = manager.companionToolLaunchContext() else {
-            companionToolState.activeTool = nil
-            companionToolState.presentation = .closed
-            rootSplitVC?.updateCompanionPane(state: companionToolState)
+            closeCompanionTool()
             return
         }
 
-        companionToolController?.show(tool: tool, context: context, focus: false)
-        rootSplitVC?.updateCompanionPane(state: companionToolState)
+        showCompanionTool(tool, context: context, focus: false)
     }
 
     @objc private func openLazygitMenuAction() {

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -237,6 +237,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowController.onToggleSidebar = { [weak splitVC] in
             splitVC?.toggleSidebar()
         }
+        windowController.onToggleFiles = { [weak self] in
+            self?.toggleCompanionTool(.yazi)
+        }
+        windowController.onToggleGit = { [weak self] in
+            self?.toggleCompanionTool(.lazygit)
+        }
 
         windowController.onShowCreateWorktreePanel = { [weak self] in
             self?.showCreateWorktreePanel()

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -1267,18 +1267,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func toggleCompanionTool(_ tool: CompanionTool) {
-        guard let manager = workspaceManager,
-              let context = manager.companionToolLaunchContext() else {
-            NSSound.beep()
-            return
-        }
-
         let sameToolVisible = companionToolState.activeTool == tool && companionToolState.isVisible
         let toolIsFocused = companionToolController?.isFocused(in: mainWindowController?.window) == true
 
         if sameToolVisible && toolIsFocused {
             closeCompanionTool()
             terminalAreaController?.focusCurrentSurface()
+            return
+        }
+
+        guard let manager = workspaceManager,
+              let context = manager.companionToolLaunchContext() else {
+            NSSound.beep()
             return
         }
 

--- a/Sources/Mori/App/CompanionToolPaneController.swift
+++ b/Sources/Mori/App/CompanionToolPaneController.swift
@@ -7,12 +7,7 @@ enum CompanionTool: String, CaseIterable {
     case yazi
     case lazygit
 
-    var command: String {
-        switch self {
-        case .yazi: "yazi"
-        case .lazygit: "lazygit"
-        }
-    }
+    var command: String { rawValue }
 
     var title: String {
         switch self {
@@ -25,7 +20,6 @@ enum CompanionTool: String, CaseIterable {
 enum CompanionToolPanePresentation {
     case closed
     case docked
-    case focused
 }
 
 struct CompanionToolPaneState {
@@ -126,8 +120,9 @@ final class CompanionToolPaneController: NSViewController {
     func show(tool: CompanionTool, context: CompanionToolLaunchContext, focus: Bool = true) {
         activeTool = tool
         titleLabel.stringValue = tool.title
+        let identity = "tool|\(tool.rawValue)|\(context.location.endpointKey)|\(context.workspaceID)"
         terminalController.attachToCommand(
-            identity: toolIdentity(tool: tool, context: context),
+            identity: identity,
             command: tool.command,
             workingDirectory: context.workingDirectory,
             location: context.location,
@@ -136,10 +131,6 @@ final class CompanionToolPaneController: NSViewController {
         if focus {
             terminalController.focusCurrentSurface()
         }
-    }
-
-    func focusTool() {
-        terminalController.focusCurrentSurface()
     }
 
     func isFocused(in window: NSWindow?) -> Bool {
@@ -154,10 +145,6 @@ final class CompanionToolPaneController: NSViewController {
         dividerView.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.45).cgColor
         titleLabel.textColor = .secondaryLabelColor
         terminalController.updateAppearance(themeInfo: themeInfo, isKeyWindow: isKeyWindow)
-    }
-
-    private func toolIdentity(tool: CompanionTool, context: CompanionToolLaunchContext) -> String {
-        "tool|\(tool.rawValue)|\(context.location.endpointKey)|\(context.workspaceID)"
     }
 
     private func headerBackgroundColor(for themeInfo: GhosttyThemeInfo) -> NSColor {

--- a/Sources/Mori/App/CompanionToolPaneController.swift
+++ b/Sources/Mori/App/CompanionToolPaneController.swift
@@ -1,0 +1,169 @@
+import AppKit
+import MoriCore
+import MoriTerminal
+
+@MainActor
+enum CompanionTool: String, CaseIterable {
+    case yazi
+    case lazygit
+
+    var command: String {
+        switch self {
+        case .yazi: "yazi"
+        case .lazygit: "lazygit"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .yazi: .localized("Files")
+        case .lazygit: .localized("Git")
+        }
+    }
+}
+
+enum CompanionToolPanePresentation {
+    case closed
+    case docked
+    case focused
+}
+
+struct CompanionToolPaneState {
+    var activeTool: CompanionTool?
+    var presentation: CompanionToolPanePresentation
+    var width: CGFloat
+
+    static let defaultWidth: CGFloat = 420
+
+    init(
+        activeTool: CompanionTool? = nil,
+        presentation: CompanionToolPanePresentation = .closed,
+        width: CGFloat = Self.defaultWidth
+    ) {
+        self.activeTool = activeTool
+        self.presentation = presentation
+        self.width = width
+    }
+
+    var isVisible: Bool {
+        presentation != .closed && activeTool != nil
+    }
+}
+
+struct CompanionToolLaunchContext {
+    let workspaceID: String
+    let workingDirectory: String
+    let location: WorkspaceLocation
+}
+
+@MainActor
+final class CompanionToolPaneController: NSViewController {
+    private let headerView = NSView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let dividerView = NSView()
+    private let terminalController: TerminalAreaViewController
+
+    private(set) var activeTool: CompanionTool?
+
+    init(terminalHost: TerminalHost? = nil) {
+        self.terminalController = TerminalAreaViewController(terminalHost: terminalHost)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        let root = NSView()
+        root.wantsLayer = true
+        root.translatesAutoresizingMaskIntoConstraints = false
+
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.wantsLayer = true
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        titleLabel.lineBreakMode = .byTruncatingTail
+
+        dividerView.translatesAutoresizingMaskIntoConstraints = false
+        dividerView.wantsLayer = true
+
+        addChild(terminalController)
+        let terminalView = terminalController.view
+        terminalView.translatesAutoresizingMaskIntoConstraints = false
+
+        root.addSubview(headerView)
+        root.addSubview(dividerView)
+        root.addSubview(terminalView)
+        headerView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: root.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: 28),
+
+            titleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -10),
+            titleLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+
+            dividerView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
+            dividerView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            dividerView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            dividerView.heightAnchor.constraint(equalToConstant: 1),
+
+            terminalView.topAnchor.constraint(equalTo: dividerView.bottomAnchor),
+            terminalView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            terminalView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            terminalView.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+        ])
+
+        self.view = root
+    }
+
+    func show(tool: CompanionTool, context: CompanionToolLaunchContext, focus: Bool = true) {
+        activeTool = tool
+        titleLabel.stringValue = tool.title
+        terminalController.attachToCommand(
+            identity: toolIdentity(tool: tool, context: context),
+            command: tool.command,
+            workingDirectory: context.workingDirectory,
+            location: context.location,
+            focus: focus
+        )
+        if focus {
+            terminalController.focusCurrentSurface()
+        }
+    }
+
+    func focusTool() {
+        terminalController.focusCurrentSurface()
+    }
+
+    func isFocused(in window: NSWindow?) -> Bool {
+        guard let responder = window?.firstResponder as? NSView else { return false }
+        return responder.isDescendant(of: view)
+    }
+
+    func updateAppearance(themeInfo: GhosttyThemeInfo, isKeyWindow: Bool) {
+        view.appearance = NSAppearance(named: themeInfo.isDark ? .darkAqua : .aqua)
+        view.layer?.backgroundColor = themeInfo.effectiveBackground.cgColor
+        headerView.layer?.backgroundColor = headerBackgroundColor(for: themeInfo).cgColor
+        dividerView.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.45).cgColor
+        titleLabel.textColor = .secondaryLabelColor
+        terminalController.updateAppearance(themeInfo: themeInfo, isKeyWindow: isKeyWindow)
+    }
+
+    private func toolIdentity(tool: CompanionTool, context: CompanionToolLaunchContext) -> String {
+        "tool|\(tool.rawValue)|\(context.location.endpointKey)|\(context.workspaceID)"
+    }
+
+    private func headerBackgroundColor(for themeInfo: GhosttyThemeInfo) -> NSColor {
+        let base = themeInfo.effectiveBackground.usingColorSpace(.deviceRGB) ?? themeInfo.effectiveBackground
+        let blend: CGFloat = themeInfo.isDark ? 0.12 : 0.06
+        let tint = themeInfo.isDark ? NSColor.white : NSColor.black
+        return base.blended(withFraction: blend, of: tint) ?? base
+    }
+}

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -186,6 +186,7 @@ extension MainWindowController: NSToolbarDelegate {
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
         let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+        let compactSplitSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
 
         switch itemIdentifier {
         case ToolbarID.toggleSidebar:
@@ -216,7 +217,10 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Split Right")
             item.paletteLabel = .localized("Split Right")
             item.toolTip = .localized("Split the current pane to the right")
-            item.image = NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: .localized("Split Right"))
+            item.image = NSImage(
+                systemSymbolName: "rectangle.split.2x1",
+                accessibilityDescription: .localized("Split Right")
+            )?.withSymbolConfiguration(compactSplitSymbolConfiguration)
             item.target = self
             item.action = #selector(splitRightClicked)
             return item
@@ -224,7 +228,10 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Split Down")
             item.paletteLabel = .localized("Split Down")
             item.toolTip = .localized("Split the current pane downward")
-            item.image = NSImage(systemSymbolName: "rectangle.split.1x2", accessibilityDescription: .localized("Split Down"))
+            item.image = NSImage(
+                systemSymbolName: "rectangle.split.1x2",
+                accessibilityDescription: .localized("Split Down")
+            )?.withSymbolConfiguration(compactSplitSymbolConfiguration)
             item.target = self
             item.action = #selector(splitDownClicked)
             return item

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -10,9 +10,13 @@ final class MainWindowController: NSWindowController {
     private enum ToolbarID {
         static let main = NSToolbar.Identifier("MoriMainToolbar")
         static let toggleSidebar = NSToolbarItem.Identifier("toggleSidebar")
+        static let files = NSToolbarItem.Identifier("openFiles")
+        static let git = NSToolbarItem.Identifier("openGit")
     }
 
     var onToggleSidebar: (() -> Void)?
+    var onToggleFiles: (() -> Void)?
+    var onToggleGit: (() -> Void)?
     var onShowCreateWorktreePanel: (() -> Void)?
 
     /// The hosting view for the update pill, overlaid on the titlebar.
@@ -110,6 +114,14 @@ final class MainWindowController: NSWindowController {
     @objc private func toggleSidebarClicked() {
         onToggleSidebar?()
     }
+
+    @objc private func toggleFilesClicked() {
+        onToggleFiles?()
+    }
+
+    @objc private func toggleGitClicked() {
+        onToggleGit?()
+    }
 }
 
 // MARK: - NSToolbarDelegate
@@ -135,11 +147,11 @@ extension MainWindowController: NSWindowDelegate {
 extension MainWindowController: NSToolbarDelegate {
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [ToolbarID.toggleSidebar, .flexibleSpace]
+        [ToolbarID.toggleSidebar, .flexibleSpace, ToolbarID.files, ToolbarID.git]
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [ToolbarID.toggleSidebar, .flexibleSpace]
+        [ToolbarID.toggleSidebar, ToolbarID.files, ToolbarID.git, .flexibleSpace]
     }
 
     func toolbar(
@@ -147,14 +159,35 @@ extension MainWindowController: NSToolbarDelegate {
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
-        guard itemIdentifier == ToolbarID.toggleSidebar else { return nil }
-        let item = NSToolbarItem(itemIdentifier: ToolbarID.toggleSidebar)
-        item.label = .localized("Toggle Sidebar")
-        item.paletteLabel = .localized("Toggle Sidebar")
-        item.toolTip = .localized("Show or hide the sidebar (⌘0)")
-        item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))
-        item.target = self
-        item.action = #selector(toggleSidebarClicked)
-        return item
+        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+
+        switch itemIdentifier {
+        case ToolbarID.toggleSidebar:
+            item.label = .localized("Toggle Sidebar")
+            item.paletteLabel = .localized("Toggle Sidebar")
+            item.toolTip = .localized("Show or hide the sidebar (⌘0)")
+            item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))
+            item.target = self
+            item.action = #selector(toggleSidebarClicked)
+            return item
+        case ToolbarID.files:
+            item.label = .localized("Files")
+            item.paletteLabel = .localized("Files")
+            item.toolTip = .localized("Open Files Companion Pane (⌘E)")
+            item.image = NSImage(systemSymbolName: "folder", accessibilityDescription: .localized("Files"))
+            item.target = self
+            item.action = #selector(toggleFilesClicked)
+            return item
+        case ToolbarID.git:
+            item.label = .localized("Git")
+            item.paletteLabel = .localized("Git")
+            item.toolTip = .localized("Open Git Companion Pane (⌘G)")
+            item.image = NSImage(systemSymbolName: "point.topleft.down.curvedto.point.bottomright.up", accessibilityDescription: .localized("Git"))
+            item.target = self
+            item.action = #selector(toggleGitClicked)
+            return item
+        default:
+            return nil
+        }
     }
 }

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -12,11 +12,15 @@ final class MainWindowController: NSWindowController {
         static let toggleSidebar = NSToolbarItem.Identifier("toggleSidebar")
         static let files = NSToolbarItem.Identifier("openFiles")
         static let git = NSToolbarItem.Identifier("openGit")
+        static let splitRight = NSToolbarItem.Identifier("splitRight")
+        static let splitDown = NSToolbarItem.Identifier("splitDown")
     }
 
     var onToggleSidebar: (() -> Void)?
     var onToggleFiles: (() -> Void)?
     var onToggleGit: (() -> Void)?
+    var onSplitRight: (() -> Void)?
+    var onSplitDown: (() -> Void)?
     var onShowCreateWorktreePanel: (() -> Void)?
 
     /// The hosting view for the update pill, overlaid on the titlebar.
@@ -122,6 +126,14 @@ final class MainWindowController: NSWindowController {
     @objc private func toggleGitClicked() {
         onToggleGit?()
     }
+
+    @objc private func splitRightClicked() {
+        onSplitRight?()
+    }
+
+    @objc private func splitDownClicked() {
+        onSplitDown?()
+    }
 }
 
 // MARK: - NSToolbarDelegate
@@ -147,11 +159,25 @@ extension MainWindowController: NSWindowDelegate {
 extension MainWindowController: NSToolbarDelegate {
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [ToolbarID.toggleSidebar, .flexibleSpace, ToolbarID.files, ToolbarID.git]
+        [
+            ToolbarID.toggleSidebar,
+            .flexibleSpace,
+            ToolbarID.files,
+            ToolbarID.git,
+            ToolbarID.splitRight,
+            ToolbarID.splitDown,
+        ]
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [ToolbarID.toggleSidebar, ToolbarID.files, ToolbarID.git, .flexibleSpace]
+        [
+            ToolbarID.toggleSidebar,
+            ToolbarID.files,
+            ToolbarID.git,
+            ToolbarID.splitRight,
+            ToolbarID.splitDown,
+            .flexibleSpace,
+        ]
     }
 
     func toolbar(
@@ -185,6 +211,22 @@ extension MainWindowController: NSToolbarDelegate {
             item.image = NSImage(systemSymbolName: "point.topleft.down.curvedto.point.bottomright.up", accessibilityDescription: .localized("Git"))
             item.target = self
             item.action = #selector(toggleGitClicked)
+            return item
+        case ToolbarID.splitRight:
+            item.label = .localized("Split Right")
+            item.paletteLabel = .localized("Split Right")
+            item.toolTip = .localized("Split the current pane to the right")
+            item.image = NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: .localized("Split Right"))
+            item.target = self
+            item.action = #selector(splitRightClicked)
+            return item
+        case ToolbarID.splitDown:
+            item.label = .localized("Split Down")
+            item.paletteLabel = .localized("Split Down")
+            item.toolTip = .localized("Split the current pane downward")
+            item.image = NSImage(systemSymbolName: "rectangle.split.1x2", accessibilityDescription: .localized("Split Down"))
+            item.target = self
+            item.action = #selector(splitDownClicked)
             return item
         default:
             return nil

--- a/Sources/Mori/App/RootSplitViewController.swift
+++ b/Sources/Mori/App/RootSplitViewController.swift
@@ -182,9 +182,9 @@ final class RootSplitViewController: NSViewController {
         case .sidebar:
             sidebarWidth = x.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
         case .companion:
-            let availableRight = view.bounds.width - sidebarVisibleWidth - sidebarDividerVisibleWidth
-            let rawWidth = availableRight - x
-            let maxAllowed = max(Self.companionMinWidth, availableRight - Self.minimumContentWidth)
+            let availableWidth = view.bounds.width - sidebarVisibleWidth - sidebarDividerVisibleWidth
+            let rawWidth = view.bounds.width - x
+            let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
             companionWidth = rawWidth.clamped(to: Self.companionMinWidth, min(Self.companionMaxWidth, maxAllowed))
             toolPaneState.width = companionWidth
             onCompanionWidthChanged?(companionWidth)

--- a/Sources/Mori/App/RootSplitViewController.swift
+++ b/Sources/Mori/App/RootSplitViewController.swift
@@ -3,48 +3,79 @@ import AppKit
 @MainActor
 final class RootSplitViewController: NSViewController {
 
+    private enum DividerDragTarget {
+        case sidebar
+        case companion
+    }
+
     private(set) var sidebarController: NSViewController
     private(set) var contentController: NSViewController
+    private(set) var companionController: NSViewController
 
-    private static let widthKey = "MoriSidebarWidth"
-    private static let minWidth: CGFloat = 180
-    private static let maxWidth: CGFloat = 400
-    private static let hitWidth: CGFloat = 8
+    private static let sidebarWidthKey = "MoriSidebarWidth"
+    private static let companionWidthKey = "MoriCompanionToolPaneWidth"
+    private static let sidebarMinWidth: CGFloat = 180
+    private static let sidebarMaxWidth: CGFloat = 400
+    private static let companionMinWidth: CGFloat = 320
+    private static let companionMaxWidth: CGFloat = 720
+    private static let dividerHitWidth: CGFloat = 8
+    private static let minimumContentWidth: CGFloat = 420
 
     private let sidebarContainer = NSView()
-    private let dividerView = NSView()
+    private let sidebarDividerView = NSView()
     private let contentContainer = NSView()
-    private var sidebarWidth: CGFloat = 280
-    private var isDragging = false
-    private var collapsed = false
+    private let companionDividerView = NSView()
+    private let companionContainer = NSView()
 
-    init(sidebarController: NSViewController, contentController: NSViewController) {
+    private var sidebarWidth: CGFloat = 280
+    private var companionWidth: CGFloat = CompanionToolPaneState.defaultWidth
+    private var dragTarget: DividerDragTarget?
+    private var collapsed = false
+    private var toolPaneState = CompanionToolPaneState()
+
+    var onCompanionWidthChanged: ((CGFloat) -> Void)?
+
+    init(
+        sidebarController: NSViewController,
+        contentController: NSViewController,
+        companionController: NSViewController
+    ) {
         self.sidebarController = sidebarController
         self.contentController = contentController
+        self.companionController = companionController
         super.init(nibName: nil, bundle: nil)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
-    // MARK: - Lifecycle
-
     override func loadView() {
         let root = NSView()
         root.wantsLayer = true
-        dividerView.wantsLayer = true
-        dividerView.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        sidebarDividerView.wantsLayer = true
+        sidebarDividerView.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        companionDividerView.wantsLayer = true
+        companionDividerView.layer?.backgroundColor = NSColor.separatorColor.cgColor
 
-        for v in [sidebarContainer, dividerView, contentContainer] {
-            root.addSubview(v)
+        for subview in [sidebarContainer, sidebarDividerView, contentContainer, companionDividerView, companionContainer] {
+            root.addSubview(subview)
         }
         self.view = root
 
         embed(sidebarController, in: sidebarContainer)
         embed(contentController, in: contentContainer)
+        embed(companionController, in: companionContainer)
 
-        let saved = UserDefaults.standard.double(forKey: Self.widthKey)
-        if saved > 0 { sidebarWidth = saved.clamped(to: Self.minWidth, Self.maxWidth) }
+        let savedSidebarWidth = UserDefaults.standard.double(forKey: Self.sidebarWidthKey)
+        if savedSidebarWidth > 0 {
+            sidebarWidth = savedSidebarWidth.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
+        }
+
+        let savedCompanionWidth = UserDefaults.standard.double(forKey: Self.companionWidthKey)
+        if savedCompanionWidth > 0 {
+            companionWidth = savedCompanionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+            toolPaneState.width = companionWidth
+        }
     }
 
     override func viewDidLayout() {
@@ -52,57 +83,132 @@ final class RootSplitViewController: NSViewController {
         updateLayout()
     }
 
-    // MARK: - Layout
-
     private func updateLayout() {
-        let b = view.bounds
-        let sw: CGFloat = collapsed ? 0 : sidebarWidth
-        let dw: CGFloat = collapsed ? 0 : 1
+        let bounds = view.bounds
+        let sidebarWidth = collapsed ? 0 : self.sidebarWidth
+        let sidebarDividerWidth: CGFloat = collapsed ? 0 : 1
+        let availableWidth = bounds.width - sidebarWidth - sidebarDividerWidth
+        let companionVisible = toolPaneState.isVisible
+        let companionFocused = toolPaneState.presentation == .focused && companionVisible
+        let companionDividerWidth: CGFloat = companionVisible && !companionFocused ? 1 : 0
 
-        sidebarContainer.frame = NSRect(x: 0, y: 0, width: sw, height: b.height)
-        dividerView.frame = NSRect(x: sw, y: 0, width: dw, height: b.height)
-        contentContainer.frame = NSRect(x: sw + dw, y: 0, width: b.width - sw - dw, height: b.height)
+        let resolvedCompanionWidth: CGFloat
+        if companionFocused {
+            resolvedCompanionWidth = availableWidth
+        } else if companionVisible {
+            let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
+            resolvedCompanionWidth = min(companionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth), maxAllowed)
+        } else {
+            resolvedCompanionWidth = 0
+        }
+
+        let contentWidth = companionFocused
+            ? 0
+            : max(0, availableWidth - companionDividerWidth - resolvedCompanionWidth)
+
+        sidebarContainer.frame = NSRect(x: 0, y: 0, width: sidebarWidth, height: bounds.height)
+        sidebarDividerView.frame = NSRect(x: sidebarWidth, y: 0, width: sidebarDividerWidth, height: bounds.height)
+        contentContainer.frame = NSRect(x: sidebarWidth + sidebarDividerWidth, y: 0, width: contentWidth, height: bounds.height)
+        companionDividerView.frame = NSRect(
+            x: sidebarWidth + sidebarDividerWidth + contentWidth,
+            y: 0,
+            width: companionDividerWidth,
+            height: bounds.height
+        )
+        companionContainer.frame = NSRect(
+            x: sidebarWidth + sidebarDividerWidth + contentWidth + companionDividerWidth,
+            y: 0,
+            width: resolvedCompanionWidth,
+            height: bounds.height
+        )
+
         sidebarContainer.isHidden = collapsed
-        dividerView.isHidden = collapsed
+        sidebarDividerView.isHidden = collapsed
+        contentContainer.isHidden = companionFocused
+        companionContainer.isHidden = !companionVisible
+        companionDividerView.isHidden = !companionVisible || companionFocused
 
         view.discardCursorRects()
         if !collapsed {
-            let center = sw + dw / 2
-            let rect = NSRect(x: center - Self.hitWidth / 2, y: 0, width: Self.hitWidth, height: b.height)
-            view.addCursorRect(rect, cursor: .resizeLeftRight)
+            let sidebarCenter = sidebarWidth + sidebarDividerWidth / 2
+            let sidebarRect = NSRect(
+                x: sidebarCenter - Self.dividerHitWidth / 2,
+                y: 0,
+                width: Self.dividerHitWidth,
+                height: bounds.height
+            )
+            view.addCursorRect(sidebarRect, cursor: .resizeLeftRight)
+        }
+
+        if companionVisible && !companionFocused {
+            let companionCenter = sidebarWidth + sidebarDividerWidth + contentWidth + companionDividerWidth / 2
+            let companionRect = NSRect(
+                x: companionCenter - Self.dividerHitWidth / 2,
+                y: 0,
+                width: Self.dividerHitWidth,
+                height: bounds.height
+            )
+            view.addCursorRect(companionRect, cursor: .resizeLeftRight)
         }
     }
 
-    // MARK: - Divider drag
-
-    private func hitDivider(_ event: NSEvent) -> Bool {
-        guard !collapsed else { return false }
+    private func hitDragTarget(_ event: NSEvent) -> DividerDragTarget? {
         let x = view.convert(event.locationInWindow, from: nil).x
-        return abs(x - sidebarWidth) <= Self.hitWidth / 2
+        if !collapsed, abs(x - sidebarWidth) <= Self.dividerHitWidth / 2 {
+            return .sidebar
+        }
+
+        guard toolPaneState.isVisible, toolPaneState.presentation == .docked else { return nil }
+        let companionDividerX = companionContainer.frame.minX
+        if abs(x - companionDividerX) <= Self.dividerHitWidth / 2 {
+            return .companion
+        }
+        return nil
     }
 
     override func mouseDown(with event: NSEvent) {
-        if hitDivider(event) { isDragging = true; NSCursor.resizeLeftRight.push() }
-        else { super.mouseDown(with: event) }
+        if let target = hitDragTarget(event) {
+            dragTarget = target
+            NSCursor.resizeLeftRight.push()
+        } else {
+            super.mouseDown(with: event)
+        }
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard isDragging else { super.mouseDragged(with: event); return }
-        sidebarWidth = view.convert(event.locationInWindow, from: nil).x
-            .clamped(to: Self.minWidth, Self.maxWidth)
+        guard let dragTarget else {
+            super.mouseDragged(with: event)
+            return
+        }
+
+        let x = view.convert(event.locationInWindow, from: nil).x
+        switch dragTarget {
+        case .sidebar:
+            sidebarWidth = x.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
+        case .companion:
+            let availableRight = view.bounds.width - sidebarVisibleWidth - sidebarDividerVisibleWidth
+            let rawWidth = availableRight - x
+            let maxAllowed = max(Self.companionMinWidth, availableRight - Self.minimumContentWidth)
+            companionWidth = rawWidth.clamped(to: Self.companionMinWidth, min(Self.companionMaxWidth, maxAllowed))
+            toolPaneState.width = companionWidth
+            onCompanionWidthChanged?(companionWidth)
+        }
         updateLayout()
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard isDragging else { super.mouseUp(with: event); return }
-        isDragging = false
+        guard dragTarget != nil else {
+            super.mouseUp(with: event)
+            return
+        }
+        dragTarget = nil
         NSCursor.pop()
         saveSidebarWidth()
+        saveCompanionWidth()
     }
 
-    // MARK: - Public
-
     var isSidebarCollapsed: Bool { collapsed }
+    var currentCompanionWidth: CGFloat { companionWidth }
 
     func toggleSidebar() {
         NSAnimationContext.runAnimationGroup { ctx in
@@ -113,9 +219,20 @@ final class RootSplitViewController: NSViewController {
         }
     }
 
+    func updateCompanionPane(state: CompanionToolPaneState) {
+        toolPaneState = state
+        companionWidth = state.width.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+        updateLayout()
+    }
+
     func saveSidebarWidth() {
         guard !collapsed, sidebarWidth > 0 else { return }
-        UserDefaults.standard.set(Double(sidebarWidth), forKey: Self.widthKey)
+        UserDefaults.standard.set(Double(sidebarWidth), forKey: Self.sidebarWidthKey)
+    }
+
+    func saveCompanionWidth() {
+        guard toolPaneState.isVisible, companionWidth > 0 else { return }
+        UserDefaults.standard.set(Double(companionWidth), forKey: Self.companionWidthKey)
     }
 
     func replaceContentController(with controller: NSViewController) {
@@ -126,7 +243,13 @@ final class RootSplitViewController: NSViewController {
         updateLayout()
     }
 
-    // MARK: - Helpers
+    private var sidebarVisibleWidth: CGFloat {
+        collapsed ? 0 : sidebarWidth
+    }
+
+    private var sidebarDividerVisibleWidth: CGFloat {
+        collapsed ? 0 : 1
+    }
 
     private func embed(_ vc: NSViewController, in container: NSView) {
         addChild(vc)

--- a/Sources/Mori/App/RootSplitViewController.swift
+++ b/Sources/Mori/App/RootSplitViewController.swift
@@ -66,14 +66,14 @@ final class RootSplitViewController: NSViewController {
         embed(contentController, in: contentContainer)
         embed(companionController, in: companionContainer)
 
-        let savedSidebarWidth = UserDefaults.standard.double(forKey: Self.sidebarWidthKey)
-        if savedSidebarWidth > 0 {
-            sidebarWidth = savedSidebarWidth.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
+        let savedSidebar = CGFloat(UserDefaults.standard.double(forKey: Self.sidebarWidthKey))
+        if savedSidebar > 0 {
+            sidebarWidth = savedSidebar.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
         }
 
-        let savedCompanionWidth = UserDefaults.standard.double(forKey: Self.companionWidthKey)
-        if savedCompanionWidth > 0 {
-            companionWidth = savedCompanionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+        let savedCompanion = CGFloat(UserDefaults.standard.double(forKey: Self.companionWidthKey))
+        if savedCompanion > 0 {
+            companionWidth = savedCompanion.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
             toolPaneState.width = companionWidth
         }
     }
@@ -83,28 +83,24 @@ final class RootSplitViewController: NSViewController {
         updateLayout()
     }
 
+    private func resolvedCompanionWidth(given availableWidth: CGFloat) -> CGFloat {
+        guard toolPaneState.isVisible else { return 0 }
+
+        let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
+        let clampedWidth = companionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+        return min(clampedWidth, maxAllowed)
+    }
+
     private func updateLayout() {
         let bounds = view.bounds
         let sidebarWidth = collapsed ? 0 : self.sidebarWidth
         let sidebarDividerWidth: CGFloat = collapsed ? 0 : 1
         let availableWidth = bounds.width - sidebarWidth - sidebarDividerWidth
         let companionVisible = toolPaneState.isVisible
-        let companionFocused = toolPaneState.presentation == .focused && companionVisible
-        let companionDividerWidth: CGFloat = companionVisible && !companionFocused ? 1 : 0
+        let companionDividerWidth: CGFloat = companionVisible ? 1 : 0
 
-        let resolvedCompanionWidth: CGFloat
-        if companionFocused {
-            resolvedCompanionWidth = availableWidth
-        } else if companionVisible {
-            let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
-            resolvedCompanionWidth = min(companionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth), maxAllowed)
-        } else {
-            resolvedCompanionWidth = 0
-        }
-
-        let contentWidth = companionFocused
-            ? 0
-            : max(0, availableWidth - companionDividerWidth - resolvedCompanionWidth)
+        let resolvedCompanionWidth = resolvedCompanionWidth(given: availableWidth)
+        let contentWidth = max(0, availableWidth - companionDividerWidth - resolvedCompanionWidth)
 
         sidebarContainer.frame = NSRect(x: 0, y: 0, width: sidebarWidth, height: bounds.height)
         sidebarDividerView.frame = NSRect(x: sidebarWidth, y: 0, width: sidebarDividerWidth, height: bounds.height)
@@ -124,9 +120,9 @@ final class RootSplitViewController: NSViewController {
 
         sidebarContainer.isHidden = collapsed
         sidebarDividerView.isHidden = collapsed
-        contentContainer.isHidden = companionFocused
+        contentContainer.isHidden = false
         companionContainer.isHidden = !companionVisible
-        companionDividerView.isHidden = !companionVisible || companionFocused
+        companionDividerView.isHidden = !companionVisible
 
         view.discardCursorRects()
         if !collapsed {
@@ -140,7 +136,7 @@ final class RootSplitViewController: NSViewController {
             view.addCursorRect(sidebarRect, cursor: .resizeLeftRight)
         }
 
-        if companionVisible && !companionFocused {
+        if companionVisible {
             let companionCenter = sidebarWidth + sidebarDividerWidth + contentWidth + companionDividerWidth / 2
             let companionRect = NSRect(
                 x: companionCenter - Self.dividerHitWidth / 2,
@@ -158,7 +154,7 @@ final class RootSplitViewController: NSViewController {
             return .sidebar
         }
 
-        guard toolPaneState.isVisible, toolPaneState.presentation == .docked else { return nil }
+        guard toolPaneState.isVisible else { return nil }
         let companionDividerX = companionContainer.frame.minX
         if abs(x - companionDividerX) <= Self.dividerHitWidth / 2 {
             return .companion
@@ -267,11 +263,5 @@ final class RootSplitViewController: NSViewController {
 private extension CGFloat {
     func clamped(to minVal: CGFloat, _ maxVal: CGFloat) -> CGFloat {
         Swift.min(Swift.max(self, minVal), maxVal)
-    }
-}
-
-private extension Double {
-    func clamped(to minVal: CGFloat, _ maxVal: CGFloat) -> CGFloat {
-        CGFloat(self).clamped(to: minVal, maxVal)
     }
 }

--- a/Sources/Mori/App/RootSplitViewController.swift
+++ b/Sources/Mori/App/RootSplitViewController.swift
@@ -17,9 +17,7 @@ final class RootSplitViewController: NSViewController {
     private static let sidebarMinWidth: CGFloat = 180
     private static let sidebarMaxWidth: CGFloat = 400
     private static let companionMinWidth: CGFloat = 320
-    private static let companionMaxWidth: CGFloat = 720
     private static let dividerHitWidth: CGFloat = 8
-    private static let minimumContentWidth: CGFloat = 420
 
     private let sidebarContainer = NSView()
     private let sidebarDividerView = NSView()
@@ -73,7 +71,7 @@ final class RootSplitViewController: NSViewController {
 
         let savedCompanion = CGFloat(UserDefaults.standard.double(forKey: Self.companionWidthKey))
         if savedCompanion > 0 {
-            companionWidth = savedCompanion.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+            companionWidth = max(Self.companionMinWidth, savedCompanion)
             toolPaneState.width = companionWidth
         }
     }
@@ -86,8 +84,8 @@ final class RootSplitViewController: NSViewController {
     private func resolvedCompanionWidth(given availableWidth: CGFloat) -> CGFloat {
         guard toolPaneState.isVisible else { return 0 }
 
-        let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
-        let clampedWidth = companionWidth.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+        let maxAllowed = max(0, availableWidth - 1)
+        let clampedWidth = max(Self.companionMinWidth, companionWidth)
         return min(clampedWidth, maxAllowed)
     }
 
@@ -183,9 +181,9 @@ final class RootSplitViewController: NSViewController {
             sidebarWidth = x.clamped(to: Self.sidebarMinWidth, Self.sidebarMaxWidth)
         case .companion:
             let availableWidth = view.bounds.width - sidebarVisibleWidth - sidebarDividerVisibleWidth
-            let rawWidth = view.bounds.width - x
-            let maxAllowed = max(Self.companionMinWidth, availableWidth - Self.minimumContentWidth)
-            companionWidth = rawWidth.clamped(to: Self.companionMinWidth, min(Self.companionMaxWidth, maxAllowed))
+            let rawWidth = view.bounds.width - x - 1
+            let maxAllowed = max(0, availableWidth - 1)
+            companionWidth = rawWidth.clamped(to: Self.companionMinWidth, maxAllowed)
             toolPaneState.width = companionWidth
             onCompanionWidthChanged?(companionWidth)
         }
@@ -217,7 +215,7 @@ final class RootSplitViewController: NSViewController {
 
     func updateCompanionPane(state: CompanionToolPaneState) {
         toolPaneState = state
-        companionWidth = state.width.clamped(to: Self.companionMinWidth, Self.companionMaxWidth)
+        companionWidth = max(Self.companionMinWidth, state.width)
         updateLayout()
     }
 

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -212,79 +212,42 @@ final class TerminalAreaViewController: NSViewController {
     ///   - location: Local or SSH remote endpoint.
     func attachToSession(sessionName: String, workingDirectory: String, location: WorkspaceLocation = .local) {
         let sessionKey = sessionIdentityKey(sessionName: sessionName, location: location)
-        isAutoReconnecting = false
-
-        // Skip if already showing this session
-        if sessionKey == currentSessionKey {
-            focusCurrentSurface()
-            return
-        }
-
-        hideEmptyState()
-
-        // Remove current surface from view (but keep in cache)
-        if let oldSurface = currentSurface {
-            oldSurface.removeFromSuperview()
-        }
-        removeResidualTerminalSubviews()
-
-        // Get or create surface from cache.
-        // Use `new-session -A` to atomically attach-or-create without shell
-        // fallback chains (`has-session && attach || new-session`).
         let escaped = shellEscape(sessionName)
         let escapedTmux = shellEscape(tmuxBinaryPath)
-        let command: String
-        let effectiveWorkingDirectory: String
+
         switch location {
         case .local:
             let escapedCwd = shellEscape(workingDirectory)
-            command = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; \(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
-            effectiveWorkingDirectory = workingDirectory
+            let command = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; \(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
+            attachSurface(identity: sessionKey, command: command, workingDirectory: workingDirectory)
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
             let remoteCwd = shellEscape(workingDirectory)
             let remoteTmux = "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:$PATH\"; tmux new-session -A -s \(escaped) -c \(remoteCwd)"
-            var sshCommand = "ssh -tt"
-            for option in sshOptionsForInteractiveTerminal(ssh) {
-                sshCommand += " \(shellEscape(option))"
-            }
-            if let port = ssh.port {
-                sshCommand += " -p \(port)"
-            }
-            sshCommand += " \(shellEscape(ssh.target)) \(shellEscape(remoteTmux))"
-            command = sshCommand
-            // Remote paths don't exist locally; use local home to avoid chdir failures.
-            effectiveWorkingDirectory = NSHomeDirectory()
+            attachSurface(identity: sessionKey, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteTmux), workingDirectory: NSHomeDirectory())
         }
-        let surface = surfaceCache.surface(
-            forSessionKey: sessionKey,
-            command: command,
-            workingDirectory: effectiveWorkingDirectory
-        )
+    }
 
-        guard surface.frame.size != .zero || view.bounds.size != .zero else {
-            showError("Failed to create terminal surface for session '\(sessionName)'.")
-            return
+    /// Attach to an arbitrary terminal command in the current workspace context.
+    /// Used for embedded utility tools like Yazi and Lazygit that should live in
+    /// Mori's companion pane instead of opening a new tmux window.
+    func attachToCommand(
+        identity: String,
+        command: String,
+        workingDirectory: String,
+        location: WorkspaceLocation = .local,
+        focus: Bool = true
+    ) {
+        let localCommand = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(command)"
+
+        switch location {
+        case .local:
+            attachSurface(identity: identity, command: localCommand, workingDirectory: workingDirectory, focus: focus)
+        case .ssh(let ssh):
+            let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
+            let remoteCommand = "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(command)"
+            attachSurface(identity: identity, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteCommand), workingDirectory: NSHomeDirectory(), focus: focus)
         }
-
-        // Add to view hierarchy
-        surface.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(surface)
-        NSLayoutConstraint.activate([
-            surface.topAnchor.constraint(equalTo: view.topAnchor),
-            surface.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            surface.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            surface.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-        ])
-
-        currentSessionKey = sessionKey
-        currentSurface = surface
-
-        // Resize to current bounds
-        terminalHost.surfaceDidResize(surface, to: view.bounds.size)
-
-        // Focus the terminal
-        focusCurrentSurface()
     }
 
     /// Detach the current terminal surface and evict it from the cache.
@@ -437,6 +400,63 @@ final class TerminalAreaViewController: NSViewController {
 
     private func sessionIdentityKey(sessionName: String, location: WorkspaceLocation) -> String {
         "\(location.endpointKey)|\(sessionName)"
+    }
+
+    private func attachSurface(identity: String, command: String, workingDirectory: String, focus: Bool = true) {
+        isAutoReconnecting = false
+
+        if identity == currentSessionKey {
+            if focus {
+                focusCurrentSurface()
+            }
+            return
+        }
+
+        hideEmptyState()
+
+        if let oldSurface = currentSurface {
+            oldSurface.removeFromSuperview()
+        }
+        removeResidualTerminalSubviews()
+
+        let surface = surfaceCache.surface(
+            forSessionKey: identity,
+            command: command,
+            workingDirectory: workingDirectory
+        )
+
+        guard surface.frame.size != .zero || view.bounds.size != .zero else {
+            showError(.localized("Failed to create embedded terminal surface."))
+            return
+        }
+
+        surface.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(surface)
+        NSLayoutConstraint.activate([
+            surface.topAnchor.constraint(equalTo: view.topAnchor),
+            surface.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            surface.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            surface.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+
+        currentSessionKey = identity
+        currentSurface = surface
+        terminalHost.surfaceDidResize(surface, to: view.bounds.size)
+        if focus {
+            focusCurrentSurface()
+        }
+    }
+
+    private func wrappedSSHCommand(ssh: SSHWorkspaceLocation, remoteCommand: String) -> String {
+        var sshCommand = "ssh -tt"
+        for option in sshOptionsForInteractiveTerminal(ssh) {
+            sshCommand += " \(shellEscape(option))"
+        }
+        if let port = ssh.port {
+            sshCommand += " -p \(port)"
+        }
+        sshCommand += " \(shellEscape(ssh.target)) \(shellEscape(remoteCommand))"
+        return sshCommand
     }
 
     /// Defensive cleanup in case a dead surface view was not tracked as current.

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -1926,6 +1926,15 @@ final class WorkspaceManager {
         return appState.worktrees.first { $0.id == id }
     }
 
+    func companionToolLaunchContext() -> CompanionToolLaunchContext? {
+        guard let worktree = selectedWorktree else { return nil }
+        return CompanionToolLaunchContext(
+            workspaceID: worktree.id.uuidString,
+            workingDirectory: activePaneCwd() ?? worktree.path,
+            location: location(for: worktree)
+        )
+    }
+
     /// Whether a worktree is currently selected (used to decide empty-state UI).
     var hasSelectedWorktree: Bool {
         selectedWorktree != nil
@@ -1980,7 +1989,7 @@ final class WorkspaceManager {
     }
 
     /// Open a CLI tool (e.g. lazygit, yazi) in a new tmux window at the active pane's cwd.
-    /// The window auto-names after the tool and closes when the tool exits.
+    /// Retained for fallback flows; the primary Mori UI now prefers the companion pane.
     func openToolWindow(command: String) async {
         guard let worktree = selectedWorktree,
               let sessionName = worktree.tmuxSessionName else { return }

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "Failed to create window" = "Failed to create window";
 "Failed to delete worktree files" = "Failed to delete worktree files";
 "Failed to open %@" = "Failed to open %@";
+"Failed to create embedded terminal surface." = "Failed to create embedded terminal surface.";
 "Failed to split pane" = "Failed to split pane";
 "Hide Mori" = "Hide Mori";
 "in use" = "in use";
@@ -60,6 +61,8 @@
 "No active session" = "No active session";
 "now" = "now";
 "OK" = "OK";
+"Files" = "Files";
+"Git" = "Git";
 "Open Lazygit" = "Open Lazygit";
 "Open Project" = "Open Project";
 "Open Project…" = "Open Project…";

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -63,6 +63,8 @@
 "OK" = "OK";
 "Files" = "Files";
 "Git" = "Git";
+"Open Files Companion Pane (⌘E)" = "Open Files Companion Pane (⌘E)";
+"Open Git Companion Pane (⌘G)" = "Open Git Companion Pane (⌘G)";
 "Open Lazygit" = "Open Lazygit";
 "Open Project" = "Open Project";
 "Open Project…" = "Open Project…";

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -65,6 +65,8 @@
 "Git" = "Git";
 "Open Files Companion Pane (⌘E)" = "Open Files Companion Pane (⌘E)";
 "Open Git Companion Pane (⌘G)" = "Open Git Companion Pane (⌘G)";
+"Split the current pane to the right" = "Split the current pane to the right";
+"Split the current pane downward" = "Split the current pane downward";
 "Open Lazygit" = "Open Lazygit";
 "Open Project" = "Open Project";
 "Open Project…" = "Open Project…";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -65,6 +65,8 @@
 "Git" = "Git";
 "Open Files Companion Pane (⌘E)" = "打开文件工具面板 (⌘E)";
 "Open Git Companion Pane (⌘G)" = "打开 Git 工具面板 (⌘G)";
+"Split the current pane to the right" = "向右拆分当前窗格";
+"Split the current pane downward" = "向下拆分当前窗格";
 "Open Lazygit" = "打开 Lazygit";
 "Open Project" = "打开项目";
 "Open Project..." = "打开项目...";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "Failed to create window" = "创建窗口失败";
 "Failed to delete worktree files" = "删除工作树文件失败";
 "Failed to open %@" = "打开 %@ 失败";
+"Failed to create embedded terminal surface." = "创建嵌入式终端界面失败。";
 "Failed to split pane" = "拆分窗格失败";
 "Hide Mori" = "隐藏 Mori";
 "in use" = "使用中";
@@ -60,6 +61,8 @@
 "No active session" = "无活跃会话";
 "now" = "刚刚";
 "OK" = "好";
+"Files" = "文件";
+"Git" = "Git";
 "Open Lazygit" = "打开 Lazygit";
 "Open Project" = "打开项目";
 "Open Project..." = "打开项目...";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -63,6 +63,8 @@
 "OK" = "好";
 "Files" = "文件";
 "Git" = "Git";
+"Open Files Companion Pane (⌘E)" = "打开文件工具面板 (⌘E)";
+"Open Git Companion Pane (⌘G)" = "打开 Git 工具面板 (⌘G)";
 "Open Lazygit" = "打开 Lazygit";
 "Open Project" = "打开项目";
 "Open Project..." = "打开项目...";


### PR DESCRIPTION
## Summary
- replace separate Yazi/Lazygit tmux-window flows with a shared in-window companion pane on the right side
- add toolbar buttons for Files, Git, Split Right, and Split Down
- route Files/Git actions through the companion pane instead of opening separate tmux tool windows
- simplify companion pane state handling by centralizing open/close transitions and removing the unused focused presentation mode
- fix companion divider drag behavior, allow closing an open pane even after launch context disappears, and remove the artificial drag cap so the pane can expand to the available width

## Testing
- swift build