### PR TITLE
✨ feat: add configurable tool path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove legacy workflow-status and sidebar-mode code paths after the unified sidebar redesign, including the `mori status` CLI command and manual sidebar status controls
 - Start replacing Yazi/Lazygit's separate tmux-window flow with a shared in-window companion tool pane that reuses one right-side split for Files and Git
 
+### 🐛 Bug Fixes
+
+- Add shared tool-path resolution for tmux, Lazygit, and Yazi, including custom install prefixes like `~/homebrew/bin`, explicit Settings overrides, and local launch paths that reuse the resolved executable instead of assuming the app's inherited PATH
+
 ## [0.3.4] - 2026-04-12
 
 ### ✨ Features

--- a/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
@@ -18,14 +18,11 @@ public struct ToolSettings: Codable, Equatable, Sendable {
     private static let defaultsKey = "toolSettings"
 
     public static func load(from defaults: UserDefaults = .standard) -> ToolSettings {
-        let model: ToolSettings
-        if let data = defaults.data(forKey: defaultsKey),
-           let decoded = try? JSONDecoder().decode(ToolSettings.self, from: data) {
-            model = decoded
-        } else {
-            model = ToolSettings()
+        guard let data = defaults.data(forKey: defaultsKey),
+              let model = try? JSONDecoder().decode(ToolSettings.self, from: data) else {
+            return ToolSettings()
         }
-        return model.withResolvedDefaults()
+        return model
     }
 
     public static func save(_ model: ToolSettings, to defaults: UserDefaults = .standard) {
@@ -38,26 +35,19 @@ public struct ToolSettings: Codable, Equatable, Sendable {
         return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
     }
 
-    private func rawPath(for command: String) -> String? {
+    public func displayPath(for command: String) -> String {
+        if let configuredPath = configuredPath(for: command) {
+            return configuredPath
+        }
+        return BinaryResolver.resolve(command: command) ?? ""
+    }
+
+    public func rawPath(for command: String) -> String? {
         switch command {
         case "tmux": tmuxPath
         case "lazygit": lazygitPath
         case "yazi": yaziPath
         default: nil
         }
-    }
-
-    private func withResolvedDefaults() -> ToolSettings {
-        ToolSettings(
-            tmuxPath: resolvedDefault(for: "tmux", current: tmuxPath),
-            lazygitPath: resolvedDefault(for: "lazygit", current: lazygitPath),
-            yaziPath: resolvedDefault(for: "yazi", current: yaziPath)
-        )
-    }
-
-    private func resolvedDefault(for command: String, current: String) -> String {
-        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.isEmpty else { return current }
-        return BinaryResolver.resolve(command: command) ?? ""
     }
 }

--- a/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
@@ -18,11 +18,14 @@ public struct ToolSettings: Codable, Equatable, Sendable {
     private static let defaultsKey = "toolSettings"
 
     public static func load(from defaults: UserDefaults = .standard) -> ToolSettings {
-        guard let data = defaults.data(forKey: defaultsKey),
-              let model = try? JSONDecoder().decode(ToolSettings.self, from: data) else {
-            return ToolSettings()
+        let model: ToolSettings
+        if let data = defaults.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode(ToolSettings.self, from: data) {
+            model = decoded
+        } else {
+            model = ToolSettings()
         }
-        return model
+        return model.withResolvedDefaults()
     }
 
     public static func save(_ model: ToolSettings, to defaults: UserDefaults = .standard) {
@@ -31,15 +34,30 @@ public struct ToolSettings: Codable, Equatable, Sendable {
     }
 
     public func configuredPath(for command: String) -> String? {
-        let rawValue: String
-        switch command {
-        case "tmux": rawValue = tmuxPath
-        case "lazygit": rawValue = lazygitPath
-        case "yazi": rawValue = yaziPath
-        default: return nil
-        }
-
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = rawPath(for: command)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
+    }
+
+    private func rawPath(for command: String) -> String? {
+        switch command {
+        case "tmux": tmuxPath
+        case "lazygit": lazygitPath
+        case "yazi": yaziPath
+        default: nil
+        }
+    }
+
+    private func withResolvedDefaults() -> ToolSettings {
+        ToolSettings(
+            tmuxPath: resolvedDefault(for: "tmux", current: tmuxPath),
+            lazygitPath: resolvedDefault(for: "lazygit", current: lazygitPath),
+            yaziPath: resolvedDefault(for: "yazi", current: yaziPath)
+        )
+    }
+
+    private func resolvedDefault(for command: String, current: String) -> String {
+        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty else { return current }
+        return BinaryResolver.resolve(command: command) ?? ""
     }
 }

--- a/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public struct ToolSettings: Codable, Equatable, Sendable {
+    public static let supportedCommands = ["tmux", "lazygit", "yazi"]
+
     public var tmuxPath: String
     public var lazygitPath: String
     public var yaziPath: String
@@ -31,8 +33,10 @@ public struct ToolSettings: Codable, Equatable, Sendable {
     }
 
     public func configuredPath(for command: String) -> String? {
-        let trimmed = rawPath(for: command)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
+        guard let trimmed = trimmedRawPath(for: command), !trimmed.isEmpty else {
+            return nil
+        }
+        return NSString(string: trimmed).expandingTildeInPath
     }
 
     public func displayPath(for command: String) -> String {
@@ -48,6 +52,23 @@ public struct ToolSettings: Codable, Equatable, Sendable {
         case "lazygit": lazygitPath
         case "yazi": yaziPath
         default: nil
+        }
+    }
+
+    public func trimmedRawPath(for command: String) -> String? {
+        rawPath(for: command)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public mutating func setRawPath(_ value: String, for command: String) {
+        switch command {
+        case "tmux":
+            tmuxPath = value
+        case "lazygit":
+            lazygitPath = value
+        case "yazi":
+            yaziPath = value
+        default:
+            break
         }
     }
 }

--- a/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Models/ToolSettings.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct ToolSettings: Codable, Equatable, Sendable {
+    public var tmuxPath: String
+    public var lazygitPath: String
+    public var yaziPath: String
+
+    public init(
+        tmuxPath: String = "",
+        lazygitPath: String = "",
+        yaziPath: String = ""
+    ) {
+        self.tmuxPath = tmuxPath
+        self.lazygitPath = lazygitPath
+        self.yaziPath = yaziPath
+    }
+
+    private static let defaultsKey = "toolSettings"
+
+    public static func load(from defaults: UserDefaults = .standard) -> ToolSettings {
+        guard let data = defaults.data(forKey: defaultsKey),
+              let model = try? JSONDecoder().decode(ToolSettings.self, from: data) else {
+            return ToolSettings()
+        }
+        return model
+    }
+
+    public static func save(_ model: ToolSettings, to defaults: UserDefaults = .standard) {
+        guard let data = try? JSONEncoder().encode(model) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+
+    public func configuredPath(for command: String) -> String? {
+        let rawValue: String
+        switch command {
+        case "tmux": rawValue = tmuxPath
+        case "lazygit": rawValue = lazygitPath
+        case "yazi": rawValue = yaziPath
+        default: return nil
+        }
+
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
+    }
+}

--- a/Packages/MoriCore/Sources/MoriCore/SSH/SSHCommandSupport.swift
+++ b/Packages/MoriCore/Sources/MoriCore/SSH/SSHCommandSupport.swift
@@ -107,6 +107,18 @@ public enum SSHCommandSupport {
         return "'\(escaped)'"
     }
 
+    public static func remoteLoginShellCommand(
+        _ command: String,
+        environment: [String: String] = [:]
+    ) -> String {
+        let exports = environment
+            .sorted { $0.key < $1.key }
+            .map { "export \($0.key)=\(shellEscape($0.value));" }
+            .joined(separator: " ")
+        let prefix = exports.isEmpty ? "" : "\(exports) "
+        return "\(prefix)exec ${SHELL:-/bin/sh} -l -c \(shellEscape(command))"
+    }
+
     public static func createAskPassScript(password: String) throws -> SSHAskPassScript {
         let temporaryDirectory = NSTemporaryDirectory()
         let templatePath = (temporaryDirectory as NSString).appendingPathComponent("mori-askpass-XXXXXX")

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+#if os(macOS)
+private enum BinaryResolverHostEnvironment {
+    static func launchctlPath() -> String? {
+        runAndCapture(
+            executablePath: "/bin/launchctl",
+            arguments: ["getenv", "PATH"]
+        )?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func pathHelperPath() -> String? {
+        guard let output = runAndCapture(
+            executablePath: "/usr/libexec/path_helper",
+            arguments: ["-s"]
+        ) else {
+            return nil
+        }
+
+        for line in output.split(separator: "\n") {
+            let text = String(line)
+            guard let start = text.range(of: "PATH=\"")?.upperBound,
+                  let end = text[start...].firstIndex(of: "\"") else { continue }
+            return String(text[start..<end])
+        }
+        return nil
+    }
+
+    private static func runAndCapture(executablePath: String, arguments: [String]) -> String? {
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}
+#endif
+
 public enum BinaryResolver {
     public static func configuredPath(
         for command: String,
@@ -27,12 +76,16 @@ public enum BinaryResolver {
     }
 
     public static var defaultSearchDirectories: [String] {
-        uniqueDirectories(
+        #if os(macOS)
+        return uniqueDirectories(
             from: [
-                pathDirectories(from: launchctlPath()),
-                pathDirectories(from: pathHelperPath()),
+                pathDirectories(from: BinaryResolverHostEnvironment.launchctlPath()),
+                pathDirectories(from: BinaryResolverHostEnvironment.pathHelperPath()),
             ]
         )
+        #else
+        return []
+        #endif
     }
 
     public static func resolve(
@@ -131,48 +184,4 @@ public enum BinaryResolver {
         return result
     }
 
-    private static func launchctlPath() -> String? {
-        runAndCapture(
-            executablePath: "/bin/launchctl",
-            arguments: ["getenv", "PATH"]
-        )?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func pathHelperPath() -> String? {
-        guard let output = runAndCapture(
-            executablePath: "/usr/libexec/path_helper",
-            arguments: ["-s"]
-        ) else {
-            return nil
-        }
-
-        for line in output.split(separator: "\n") {
-            let text = String(line)
-            guard let start = text.range(of: "PATH=\"")?.upperBound,
-                  let end = text[start...].firstIndex(of: "\"") else { continue }
-            return String(text[start..<end])
-        }
-        return nil
-    }
-
-    private static func runAndCapture(executablePath: String, arguments: [String]) -> String? {
-        let process = Process()
-        let stdout = Pipe()
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = arguments
-        process.standardOutput = stdout
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return nil
-        }
-
-        guard process.terminationStatus == 0 else { return nil }
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)
-    }
 }

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -1,6 +1,31 @@
 import Foundation
 
 public enum BinaryResolver {
+    public static func configuredPath(
+        for command: String,
+        settings: ToolSettings = ToolSettings.load()
+    ) -> String? {
+        settings.configuredPath(for: command)
+    }
+
+    public static func resolveTool(
+        command: String,
+        settings: ToolSettings = ToolSettings.load(),
+        bundledPath: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> String? {
+        resolve(
+            command: command,
+            configuredPath: configuredPath(for: command, settings: settings),
+            bundledPath: bundledPath,
+            environment: environment,
+            additionalSearchDirectories: additionalSearchDirectories,
+            isExecutable: isExecutable
+        )
+    }
+
     public static var defaultSearchDirectories: [String] {
         uniqueDirectories(
             from: [
@@ -69,7 +94,25 @@ public enum BinaryResolver {
         ) != nil
     }
 
-    static func pathDirectories(from pathValue: String?) -> [String] {
+    public static func toolExists(
+        command: String,
+        settings: ToolSettings = ToolSettings.load(),
+        bundledPath: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> Bool {
+        resolveTool(
+            command: command,
+            settings: settings,
+            bundledPath: bundledPath,
+            environment: environment,
+            additionalSearchDirectories: additionalSearchDirectories,
+            isExecutable: isExecutable
+        ) != nil
+    }
+
+    public static func pathDirectories(from pathValue: String?) -> [String] {
         guard let pathValue else { return [] }
         return pathValue
             .split(separator: ":")

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum BinaryResolver {
+    public static var defaultSearchDirectories: [String] {
+        let home = NSHomeDirectory()
+        return [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "\(home)/homebrew/bin",
+            "\(home)/.homebrew/bin",
+            "\(home)/.local/bin",
+        ]
+    }
+
+    public static func resolve(
+        command: String,
+        configuredPath: String? = nil,
+        bundledPath: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> String? {
+        if let configuredPath {
+            let expanded = NSString(string: configuredPath).expandingTildeInPath
+            if isExecutable(expanded) {
+                return expanded
+            }
+        }
+
+        if let bundledPath, isExecutable(bundledPath) {
+            return bundledPath
+        }
+
+        var seen = Set<String>()
+
+        for directory in additionalSearchDirectories {
+            let expanded = NSString(string: directory).expandingTildeInPath
+            let candidate = expanded.hasSuffix("/\(command)") ? expanded : "\(expanded)/\(command)"
+            if seen.insert(candidate).inserted, isExecutable(candidate) {
+                return candidate
+            }
+        }
+
+        guard let pathVar = environment["PATH"] else { return nil }
+        for directory in pathVar.split(separator: ":") {
+            let expanded = NSString(string: String(directory)).expandingTildeInPath
+            let candidate = "\(expanded)/\(command)"
+            if seen.insert(candidate).inserted, isExecutable(candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    public static func exists(
+        command: String,
+        configuredPath: String? = nil,
+        bundledPath: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> Bool {
+        resolve(
+            command: command,
+            configuredPath: configuredPath,
+            bundledPath: bundledPath,
+            environment: environment,
+            additionalSearchDirectories: additionalSearchDirectories,
+            isExecutable: isExecutable
+        ) != nil
+    }
+}

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -2,15 +2,12 @@ import Foundation
 
 public enum BinaryResolver {
     public static var defaultSearchDirectories: [String] {
-        let home = NSHomeDirectory()
-        return [
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/opt/local/bin",
-            "\(home)/homebrew/bin",
-            "\(home)/.homebrew/bin",
-            "\(home)/.local/bin",
-        ]
+        uniqueDirectories(
+            from: [
+                pathDirectories(from: launchctlPath()),
+                pathDirectories(from: pathHelperPath()),
+            ]
+        )
     }
 
     public static func resolve(
@@ -70,5 +67,69 @@ public enum BinaryResolver {
             additionalSearchDirectories: additionalSearchDirectories,
             isExecutable: isExecutable
         ) != nil
+    }
+
+    static func pathDirectories(from pathValue: String?) -> [String] {
+        guard let pathValue else { return [] }
+        return pathValue
+            .split(separator: ":")
+            .map { NSString(string: String($0)).expandingTildeInPath }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func uniqueDirectories(from groups: [[String]]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for directory in groups.joined() {
+            if seen.insert(directory).inserted {
+                result.append(directory)
+            }
+        }
+        return result
+    }
+
+    private static func launchctlPath() -> String? {
+        runAndCapture(
+            executablePath: "/bin/launchctl",
+            arguments: ["getenv", "PATH"]
+        )?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func pathHelperPath() -> String? {
+        guard let output = runAndCapture(
+            executablePath: "/usr/libexec/path_helper",
+            arguments: ["-s"]
+        ) else {
+            return nil
+        }
+
+        for line in output.split(separator: "\n") {
+            let text = String(line)
+            guard let start = text.range(of: "PATH=\"")?.upperBound,
+                  let end = text[start...].firstIndex(of: "\"") else { continue }
+            return String(text[start..<end])
+        }
+        return nil
+    }
+
+    private static func runAndCapture(executablePath: String, arguments: [String]) -> String? {
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -50,6 +50,33 @@ private enum BinaryResolverHostEnvironment {
 #endif
 
 public enum BinaryResolver {
+    #if os(macOS)
+    private static let cachedDefaultSearchDirectories: [String] = uniqueDirectories(
+        from: [
+            pathDirectories(from: BinaryResolverHostEnvironment.launchctlPath()),
+            pathDirectories(from: BinaryResolverHostEnvironment.pathHelperPath()),
+            explicitFallbackDirectories,
+        ]
+    )
+    #endif
+
+    private static let explicitFallbackDirectories: [String] = uniqueDirectories(
+        from: [[
+            "~/homebrew/bin",
+            "~/.homebrew/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "~/.local/bin",
+            "~/.nix-profile/bin",
+            "/nix/var/nix/profiles/default/bin",
+            "~/.local/share/mise/shims",
+            "~/.asdf/shims",
+            "~/.cargo/bin",
+            "~/bin",
+        ]]
+    )
+
     public static func configuredPath(
         for command: String,
         settings: ToolSettings = ToolSettings.load()
@@ -77,15 +104,37 @@ public enum BinaryResolver {
 
     public static var defaultSearchDirectories: [String] {
         #if os(macOS)
-        return uniqueDirectories(
-            from: [
-                pathDirectories(from: BinaryResolverHostEnvironment.launchctlPath()),
-                pathDirectories(from: BinaryResolverHostEnvironment.pathHelperPath()),
-            ]
-        )
+        return cachedDefaultSearchDirectories
         #else
-        return []
+        return explicitFallbackDirectories
         #endif
+    }
+
+    public static func synthesizedPATH(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories
+    ) -> String {
+        uniqueDirectories(
+            from: [
+                pathDirectories(from: environment["PATH"]),
+                additionalSearchDirectories,
+            ]
+        ).joined(separator: ":")
+    }
+
+    public static func synthesizedEnvironment(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalSearchDirectories: [String] = defaultSearchDirectories
+    ) -> [String: String] {
+        var merged = environment
+        let pathValue = synthesizedPATH(
+            environment: environment,
+            additionalSearchDirectories: additionalSearchDirectories
+        )
+        if !pathValue.isEmpty {
+            merged["PATH"] = pathValue
+        }
+        return merged
     }
 
     public static func resolve(
@@ -106,7 +155,7 @@ public enum BinaryResolver {
 
         if let resolvedPath = firstExecutablePath(
             for: command,
-            searchDirectories: additionalSearchDirectories,
+            searchDirectories: pathDirectories(from: environment["PATH"]),
             isExecutable: isExecutable
         ) {
             return resolvedPath
@@ -114,7 +163,7 @@ public enum BinaryResolver {
 
         return firstExecutablePath(
             for: command,
-            searchDirectories: pathDirectories(from: environment["PATH"]),
+            searchDirectories: additionalSearchDirectories,
             isExecutable: isExecutable
         )
     }
@@ -203,9 +252,9 @@ public enum BinaryResolver {
         var seen = Set<String>()
         var result: [String] = []
         for directory in groups.joined() {
-            if seen.insert(directory).inserted {
-                result.append(directory)
-            }
+            let expanded = NSString(string: directory).expandingTildeInPath
+            guard !expanded.isEmpty, seen.insert(expanded).inserted else { continue }
+            result.append(expanded)
         }
         return result
     }

--- a/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
+++ b/Packages/MoriCore/Sources/MoriCore/Tools/BinaryResolver.swift
@@ -96,37 +96,27 @@ public enum BinaryResolver {
         additionalSearchDirectories: [String] = defaultSearchDirectories,
         isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
     ) -> String? {
-        if let configuredPath {
-            let expanded = NSString(string: configuredPath).expandingTildeInPath
-            if isExecutable(expanded) {
-                return expanded
-            }
+        if let configuredPath = validatedExecutablePath(configuredPath, isExecutable: isExecutable) {
+            return configuredPath
         }
 
-        if let bundledPath, isExecutable(bundledPath) {
+        if let bundledPath = validatedExecutablePath(bundledPath, isExecutable: isExecutable) {
             return bundledPath
         }
 
-        var seen = Set<String>()
-
-        for directory in additionalSearchDirectories {
-            let expanded = NSString(string: directory).expandingTildeInPath
-            let candidate = expanded.hasSuffix("/\(command)") ? expanded : "\(expanded)/\(command)"
-            if seen.insert(candidate).inserted, isExecutable(candidate) {
-                return candidate
-            }
+        if let resolvedPath = firstExecutablePath(
+            for: command,
+            searchDirectories: additionalSearchDirectories,
+            isExecutable: isExecutable
+        ) {
+            return resolvedPath
         }
 
-        guard let pathVar = environment["PATH"] else { return nil }
-        for directory in pathVar.split(separator: ":") {
-            let expanded = NSString(string: String(directory)).expandingTildeInPath
-            let candidate = "\(expanded)/\(command)"
-            if seen.insert(candidate).inserted, isExecutable(candidate) {
-                return candidate
-            }
-        }
-
-        return nil
+        return firstExecutablePath(
+            for: command,
+            searchDirectories: pathDirectories(from: environment["PATH"]),
+            isExecutable: isExecutable
+        )
     }
 
     public static func exists(
@@ -173,6 +163,42 @@ public enum BinaryResolver {
             .filter { !$0.isEmpty }
     }
 
+    private static func validatedExecutablePath(
+        _ path: String?,
+        isExecutable: (String) -> Bool
+    ) -> String? {
+        guard let path else { return nil }
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        guard isExecutable(expandedPath) else { return nil }
+        return expandedPath
+    }
+
+    private static func firstExecutablePath(
+        for command: String,
+        searchDirectories: [String],
+        isExecutable: (String) -> Bool
+    ) -> String? {
+        var seen = Set<String>()
+
+        for directory in searchDirectories {
+            let candidate = executablePath(for: command, in: directory)
+            guard seen.insert(candidate).inserted else { continue }
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private static func executablePath(for command: String, in directory: String) -> String {
+        let expandedDirectory = NSString(string: directory).expandingTildeInPath
+        if expandedDirectory.hasSuffix("/\(command)") {
+            return expandedDirectory
+        }
+        return "\(expandedDirectory)/\(command)"
+    }
+
     private static func uniqueDirectories(from groups: [[String]]) -> [String] {
         var seen = Set<String>()
         var result: [String] = []
@@ -183,5 +209,4 @@ public enum BinaryResolver {
         }
         return result
     }
-
 }

--- a/Packages/MoriCore/Tests/MoriCoreTests/SSHCommandSupportTests.swift
+++ b/Packages/MoriCore/Tests/MoriCoreTests/SSHCommandSupportTests.swift
@@ -69,3 +69,16 @@ func testSSHCreateAskPassScriptHasSecurePermissions() {
     let mode = (attrs?[.posixPermissions] as? NSNumber)?.intValue ?? -1
     assertEqual(mode & 0o777, 0o700, "Askpass script should be executable only by current user")
 }
+
+func testSSHRemoteLoginShellCommand() {
+    let command = SSHCommandSupport.remoteLoginShellCommand(
+        "tmux -V",
+        environment: [
+            "TERM_PROGRAM": "ghostty",
+            "STARSHIP_LOG": "error",
+        ]
+    )
+    assertTrue(command.contains("exec ${SHELL:-/bin/sh} -l -c 'tmux -V'"))
+    assertTrue(command.contains("export STARSHIP_LOG='error';"))
+    assertTrue(command.contains("export TERM_PROGRAM='ghostty';"))
+}

--- a/Packages/MoriCore/Tests/MoriCoreTests/main.swift
+++ b/Packages/MoriCore/Tests/MoriCoreTests/main.swift
@@ -1239,6 +1239,46 @@ func testAgentMessageCodable() {
     assertEqual(decoded, msg, "AgentMessage codable round-trip")
 }
 
+// MARK: - Tool Resolution Tests
+
+func testToolSettingsConfiguredPathExpandsTilde() {
+    let settings = ToolSettings(tmuxPath: "~/homebrew/bin/tmux")
+    let expected = NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath
+    assertEqual(settings.configuredPath(for: "tmux"), expected)
+    assertNil(settings.configuredPath(for: "unknown"))
+}
+
+func testBinaryResolverPrefersConfiguredPath() {
+    let resolved = BinaryResolver.resolve(
+        command: "tmux",
+        configuredPath: "~/custom/tmux",
+        environment: ["PATH": "/usr/bin:/bin"],
+        additionalSearchDirectories: [],
+        isExecutable: { $0 == NSString(string: "~/custom/tmux").expandingTildeInPath }
+    )
+    assertEqual(resolved, NSString(string: "~/custom/tmux").expandingTildeInPath)
+}
+
+func testBinaryResolverChecksFallbackDirectoriesBeforePATH() {
+    let resolved = BinaryResolver.resolve(
+        command: "tmux",
+        environment: ["PATH": "/usr/bin:/bin"],
+        additionalSearchDirectories: ["~/homebrew/bin"],
+        isExecutable: { $0 == NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath }
+    )
+    assertEqual(resolved, NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath)
+}
+
+func testBinaryResolverFallsBackToPATH() {
+    let resolved = BinaryResolver.resolve(
+        command: "lazygit",
+        environment: ["PATH": "/tmp/bin:/usr/bin"],
+        additionalSearchDirectories: [],
+        isExecutable: { $0 == "/tmp/bin/lazygit" }
+    )
+    assertEqual(resolved, "/tmp/bin/lazygit")
+}
+
 // MARK: - Main
 
 print("=== MoriCore Model Tests ===")
@@ -1355,6 +1395,12 @@ testAgentMessageParse()
 testAgentMessageParseSlashInWorktree()
 testAgentMessageParseInvalid()
 testAgentMessageCodable()
+
+// Tool resolution
+testToolSettingsConfiguredPathExpandsTilde()
+testBinaryResolverPrefersConfiguredPath()
+testBinaryResolverChecksFallbackDirectoriesBeforePATH()
+testBinaryResolverFallsBackToPATH()
 
 // KeyBinding
 runKeyBindingTests()

--- a/Packages/MoriCore/Tests/MoriCoreTests/main.swift
+++ b/Packages/MoriCore/Tests/MoriCoreTests/main.swift
@@ -1279,6 +1279,27 @@ func testBinaryResolverFallsBackToPATH() {
     assertEqual(resolved, "/tmp/bin/lazygit")
 }
 
+func testBinaryResolverResolveToolUsesToolSettings() {
+    let settings = ToolSettings(lazygitPath: "~/tools/lazygit")
+    let expected = NSString(string: "~/tools/lazygit").expandingTildeInPath
+    let resolved = BinaryResolver.resolveTool(
+        command: "lazygit",
+        settings: settings,
+        environment: ["PATH": "/usr/bin:/bin"],
+        additionalSearchDirectories: [],
+        isExecutable: { $0 == expected }
+    )
+    assertEqual(resolved, expected)
+}
+
+func testBinaryResolverPathDirectoriesParsing() {
+    let directories = BinaryResolver.pathDirectories(from: "~/bin:/usr/local/bin::/usr/bin")
+    assertEqual(directories[0], NSString(string: "~/bin").expandingTildeInPath)
+    assertEqual(directories[1], "/usr/local/bin")
+    assertEqual(directories[2], "/usr/bin")
+    assertEqual(directories.count, 3)
+}
+
 // MARK: - Main
 
 print("=== MoriCore Model Tests ===")
@@ -1401,6 +1422,8 @@ testToolSettingsConfiguredPathExpandsTilde()
 testBinaryResolverPrefersConfiguredPath()
 testBinaryResolverChecksFallbackDirectoriesBeforePATH()
 testBinaryResolverFallsBackToPATH()
+testBinaryResolverResolveToolUsesToolSettings()
+testBinaryResolverPathDirectoriesParsing()
 
 // KeyBinding
 runKeyBindingTests()

--- a/Packages/MoriCore/Tests/MoriCoreTests/main.swift
+++ b/Packages/MoriCore/Tests/MoriCoreTests/main.swift
@@ -1409,6 +1409,7 @@ testSSHRemovingBatchMode()
 testSSHShellEscape()
 testSSHAskPassEnvironmentIsMinimal()
 testSSHCreateAskPassScriptHasSecurePermissions()
+testSSHRemoteLoginShellCommand()
 
 // AgentMessage
 testAgentMessageEnvelope()

--- a/Packages/MoriCore/Tests/MoriCoreTests/main.swift
+++ b/Packages/MoriCore/Tests/MoriCoreTests/main.swift
@@ -1259,14 +1259,17 @@ func testBinaryResolverPrefersConfiguredPath() {
     assertEqual(resolved, NSString(string: "~/custom/tmux").expandingTildeInPath)
 }
 
-func testBinaryResolverChecksFallbackDirectoriesBeforePATH() {
+func testBinaryResolverPrefersPATHBeforeFallbackDirectories() {
     let resolved = BinaryResolver.resolve(
         command: "tmux",
-        environment: ["PATH": "/usr/bin:/bin"],
+        environment: ["PATH": "/custom/bin:/usr/bin:/bin"],
         additionalSearchDirectories: ["~/homebrew/bin"],
-        isExecutable: { $0 == NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath }
+        isExecutable: {
+            $0 == "/custom/bin/tmux" ||
+            $0 == NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath
+        }
     )
-    assertEqual(resolved, NSString(string: "~/homebrew/bin/tmux").expandingTildeInPath)
+    assertEqual(resolved, "/custom/bin/tmux")
 }
 
 func testBinaryResolverFallsBackToPATH() {
@@ -1298,6 +1301,27 @@ func testBinaryResolverPathDirectoriesParsing() {
     assertEqual(directories[1], "/usr/local/bin")
     assertEqual(directories[2], "/usr/bin")
     assertEqual(directories.count, 3)
+}
+
+func testBinaryResolverSynthesizedPATHPreservesPATHPrecedence() {
+    let pathValue = BinaryResolver.synthesizedPATH(
+        environment: ["PATH": "/custom/bin:/usr/bin"],
+        additionalSearchDirectories: ["~/homebrew/bin", "/usr/bin", "/opt/homebrew/bin"]
+    )
+    let expected = [
+        "/custom/bin",
+        "/usr/bin",
+        NSString(string: "~/homebrew/bin").expandingTildeInPath,
+        "/opt/homebrew/bin",
+    ].joined(separator: ":")
+    assertEqual(pathValue, expected)
+}
+
+func testBinaryResolverDefaultSearchDirectoriesIncludeExplicitFallbacks() {
+    let directories = Set(BinaryResolver.defaultSearchDirectories)
+    assertTrue(directories.contains(NSString(string: "~/homebrew/bin").expandingTildeInPath))
+    assertTrue(directories.contains("/opt/homebrew/bin"))
+    assertTrue(directories.contains("/usr/local/bin"))
 }
 
 // MARK: - Main
@@ -1421,10 +1445,12 @@ testAgentMessageCodable()
 // Tool resolution
 testToolSettingsConfiguredPathExpandsTilde()
 testBinaryResolverPrefersConfiguredPath()
-testBinaryResolverChecksFallbackDirectoriesBeforePATH()
+testBinaryResolverPrefersPATHBeforeFallbackDirectories()
 testBinaryResolverFallsBackToPATH()
 testBinaryResolverResolveToolUsesToolSettings()
 testBinaryResolverPathDirectoriesParsing()
+testBinaryResolverSynthesizedPATHPreservesPATHPrecedence()
+testBinaryResolverDefaultSearchDirectoriesIncludeExplicitFallbacks()
 
 // KeyBinding
 runKeyBindingTests()

--- a/Packages/MoriGit/Sources/MoriGit/GitCommandRunner.swift
+++ b/Packages/MoriGit/Sources/MoriGit/GitCommandRunner.swift
@@ -41,7 +41,7 @@ public actor GitCommandRunner {
 
     // MARK: - Binary Resolution
 
-    /// Resolve the git binary path. Checks common locations first, then falls back to `which git`.
+    /// Resolve the git binary path through the shared binary resolver.
     public func resolveBinaryPath() async throws -> String {
         if sshConfig != nil {
             return "git"
@@ -50,31 +50,9 @@ public actor GitCommandRunner {
             return cached
         }
 
-        let commonPaths = [
-            "/opt/homebrew/bin/git",
-            "/usr/local/bin/git",
-            "/usr/bin/git",
-        ]
-
-        for path in commonPaths {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                resolvedBinaryPath = path
-                return path
-            }
-        }
-
-        // Fall back to `which git`
-        let (output, exitCode) = try await runProcess(
-            executablePath: "/usr/bin/which",
-            arguments: ["git"]
-        )
-
-        if exitCode == 0 {
-            let path = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !path.isEmpty {
-                resolvedBinaryPath = path
-                return path
-            }
+        if let path = BinaryResolver.resolve(command: "git") {
+            resolvedBinaryPath = path
+            return path
         }
 
         throw GitError.binaryNotFound

--- a/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
+++ b/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
@@ -48,13 +48,9 @@ private final class SendableResumeGuard<T>: @unchecked Sendable {
 /// Loads the user's login shell environment on first use so that tools installed
 /// via Homebrew, mise, nix, etc. are discoverable even when launched as a .app bundle.
 public actor TmuxCommandRunner {
-    private static let commonBinaryPaths = [
-        "/opt/homebrew/bin/tmux",
-        "/usr/local/bin/tmux",
-    ]
-
     /// Cached path to the tmux binary, resolved on first use.
     private var resolvedBinaryPath: String?
+    private var resolvedConfiguredPath: String?
 
     /// User's shell environment, loaded once on first use.
     private var shellEnvironment: [String: String]?
@@ -119,32 +115,20 @@ public actor TmuxCommandRunner {
 
     /// Quick check: is tmux findable on PATH in the given environment?
     private func hasTmuxOnPath(_ env: [String: String]) -> Bool {
-        for path in Self.commonBinaryPaths {
-            if FileManager.default.isExecutableFile(atPath: path) { return true }
-        }
-        guard let pathVar = env["PATH"] else { return false }
-        return pathVar.split(separator: ":").contains { dir in
-            FileManager.default.isExecutableFile(atPath: "\(dir)/tmux")
-        }
+        BinaryResolver.exists(
+            command: "tmux",
+            configuredPath: ToolSettings.load().configuredPath(for: "tmux"),
+            environment: env
+        )
     }
 
     /// Best-effort synchronous lookup for UI launch commands before async resolution completes.
     public static func preferredBinaryPath(in environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        for path in commonBinaryPaths {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                return path
-            }
-        }
-
-        guard let pathVar = environment["PATH"] else { return nil }
-        for dir in pathVar.split(separator: ":") {
-            let candidate = "\(dir)/tmux"
-            if FileManager.default.isExecutableFile(atPath: candidate) {
-                return candidate
-            }
-        }
-
-        return nil
+        BinaryResolver.resolve(
+            command: "tmux",
+            configuredPath: ToolSettings.load().configuredPath(for: "tmux"),
+            environment: environment
+        )
     }
 
     // MARK: - Binary Resolution
@@ -155,28 +139,23 @@ public actor TmuxCommandRunner {
         if sshConfig != nil {
             return "tmux"
         }
-        if let cached = resolvedBinaryPath {
+        let configuredPath = ToolSettings.load().configuredPath(for: "tmux")
+        if let cached = resolvedBinaryPath,
+           resolvedConfiguredPath == configuredPath {
             return cached
         }
 
-        for path in Self.commonBinaryPaths {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                resolvedBinaryPath = path
-                return path
-            }
-        }
-
-        // Load user shell env and search PATH
+        // Load user shell env and search configured path, common package-manager
+        // locations, then the resolved PATH from the login shell.
         let env = await loadShellEnvironment()
-        if let pathVar = env["PATH"] {
-            let dirs = pathVar.split(separator: ":")
-            for dir in dirs {
-                let candidate = "\(dir)/tmux"
-                if FileManager.default.isExecutableFile(atPath: candidate) {
-                    resolvedBinaryPath = candidate
-                    return candidate
-                }
-            }
+        if let candidate = BinaryResolver.resolve(
+            command: "tmux",
+            configuredPath: configuredPath,
+            environment: env
+        ) {
+            resolvedBinaryPath = candidate
+            resolvedConfiguredPath = configuredPath
+            return candidate
         }
 
         throw TmuxError.binaryNotFound

--- a/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
+++ b/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
@@ -115,20 +115,12 @@ public actor TmuxCommandRunner {
 
     /// Quick check: is tmux findable on PATH in the given environment?
     private func hasTmuxOnPath(_ env: [String: String]) -> Bool {
-        BinaryResolver.exists(
-            command: "tmux",
-            configuredPath: ToolSettings.load().configuredPath(for: "tmux"),
-            environment: env
-        )
+        BinaryResolver.toolExists(command: "tmux", environment: env)
     }
 
     /// Best-effort synchronous lookup for UI launch commands before async resolution completes.
     public static func preferredBinaryPath(in environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        BinaryResolver.resolve(
-            command: "tmux",
-            configuredPath: ToolSettings.load().configuredPath(for: "tmux"),
-            environment: environment
-        )
+        BinaryResolver.resolveTool(command: "tmux", environment: environment)
     }
 
     // MARK: - Binary Resolution
@@ -139,7 +131,7 @@ public actor TmuxCommandRunner {
         if sshConfig != nil {
             return "tmux"
         }
-        let configuredPath = ToolSettings.load().configuredPath(for: "tmux")
+        let configuredPath = BinaryResolver.configuredPath(for: "tmux")
         if let cached = resolvedBinaryPath,
            resolvedConfiguredPath == configuredPath {
             return cached
@@ -148,9 +140,8 @@ public actor TmuxCommandRunner {
         // Load user shell env and search configured path, common package-manager
         // locations, then the resolved PATH from the login shell.
         let env = await loadShellEnvironment()
-        if let candidate = BinaryResolver.resolve(
+        if let candidate = BinaryResolver.resolveTool(
             command: "tmux",
-            configuredPath: configuredPath,
             environment: env
         ) {
             resolvedBinaryPath = candidate

--- a/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
+++ b/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
@@ -75,11 +75,15 @@ public actor TmuxCommandRunner {
         }
 
         // Try the inherited process environment first — this is instant and works
-        // when launched from a terminal that already has the full PATH.
+        // when launched from a terminal that already has the full PATH. For app
+        // launches with a constrained environment, synthesize PATH from the shared
+        // resolver's host probing and fallback directories before deciding whether
+        // a login shell probe is still necessary.
         let processEnv = ProcessInfo.processInfo.environment
-        if hasTmuxOnPath(processEnv) {
-            shellEnvironment = processEnv
-            return processEnv
+        let synthesizedEnv = BinaryResolver.synthesizedEnvironment(environment: processEnv)
+        if hasTmuxOnPath(synthesizedEnv) {
+            shellEnvironment = synthesizedEnv
+            return synthesizedEnv
         }
 
         // Fallback: spawn a login shell to discover the full PATH.

--- a/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
+++ b/Packages/MoriTmux/Sources/MoriTmux/TmuxCommandRunner.swift
@@ -181,7 +181,7 @@ public actor TmuxCommandRunner {
     public func run(_ arguments: [String]) async throws -> String {
         if let sshConfig {
             let tmuxCommand = (["tmux"] + arguments).map(SSHCommandSupport.shellEscape).joined(separator: " ")
-            let remoteCommand = "export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:\\$PATH\"; \(tmuxCommand)"
+            let remoteCommand = SSHCommandSupport.remoteLoginShellCommand(tmuxCommand)
 
             var sshArguments: [String] = SSHCommandSupport.connectivityOptions()
             sshArguments += sshConfig.sshOptions

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -1380,7 +1380,7 @@ private struct ToolSettingsContent: View {
                 title: "tmux",
                 description: .localized("Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux."),
                 value: $model.tmuxPath,
-                placeholder: "/opt/homebrew/bin/tmux"
+                placeholder: .localized("Resolved automatically")
             )
 
             CardDivider()
@@ -1389,7 +1389,7 @@ private struct ToolSettingsContent: View {
                 title: "lazygit",
                 description: .localized("Optional Git companion tool path."),
                 value: $model.lazygitPath,
-                placeholder: "/opt/homebrew/bin/lazygit"
+                placeholder: .localized("Resolved automatically")
             )
 
             CardDivider()
@@ -1398,7 +1398,7 @@ private struct ToolSettingsContent: View {
                 title: "yazi",
                 description: .localized("Optional file manager companion tool path."),
                 value: $model.yaziPath,
-                placeholder: "/opt/homebrew/bin/yazi"
+                placeholder: .localized("Resolved automatically")
             )
         }
 

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -1364,6 +1364,12 @@ private struct WindowSettingsContent: View {
 // MARK: - Tool Settings
 
 private struct ToolSettingsContent: View {
+    private static let tools: [(command: String, description: String)] = [
+        ("tmux", .localized("Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux.")),
+        ("lazygit", .localized("Optional Git companion tool path.")),
+        ("yazi", .localized("Optional file manager companion tool path.")),
+    ]
+
     @Binding var model: ToolSettings
     let onApply: () -> Void
 
@@ -1376,27 +1382,13 @@ private struct ToolSettingsContent: View {
             .fixedSize(horizontal: false, vertical: true)
 
         SettingsCard {
-            toolRow(
-                title: "tmux",
-                description: .localized("Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux."),
-                command: "tmux"
-            )
+            ForEach(Array(Self.tools.enumerated()), id: \.element.command) { index, tool in
+                toolRow(command: tool.command, description: tool.description)
 
-            CardDivider()
-
-            toolRow(
-                title: "lazygit",
-                description: .localized("Optional Git companion tool path."),
-                command: "lazygit"
-            )
-
-            CardDivider()
-
-            toolRow(
-                title: "yazi",
-                description: .localized("Optional file manager companion tool path."),
-                command: "yazi"
-            )
+                if index < Self.tools.count - 1 {
+                    CardDivider()
+                }
+            }
         }
 
         SettingsCard {
@@ -1423,13 +1415,9 @@ private struct ToolSettingsContent: View {
         }
     }
 
-    private func toolRow(
-        title: String,
-        description: String,
-        command: String
-    ) -> some View {
+    private func toolRow(command: String, description: String) -> some View {
         let value = toolBinding(for: command)
-        return SettingRow(title: title, description: description) {
+        return SettingRow(title: command, description: description) {
             TextField(String.localized("Resolved automatically"), text: value)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 280)
@@ -1443,23 +1431,13 @@ private struct ToolSettingsContent: View {
     private func toolBinding(for command: String) -> Binding<String> {
         Binding(
             get: {
-                let rawValue = model.rawPath(for: command)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                if rawValue.isEmpty {
-                    return model.displayPath(for: command)
+                if let rawValue = model.trimmedRawPath(for: command), !rawValue.isEmpty {
+                    return rawValue
                 }
-                return rawValue
+                return model.displayPath(for: command)
             },
             set: { newValue in
-                switch command {
-                case "tmux":
-                    model.tmuxPath = newValue
-                case "lazygit":
-                    model.lazygitPath = newValue
-                case "yazi":
-                    model.yaziPath = newValue
-                default:
-                    return
-                }
+                model.setRawPath(newValue, for: command)
             }
         )
     }

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -1417,24 +1417,39 @@ private struct ToolSettingsContent: View {
 
     private func toolRow(command: String, description: String) -> some View {
         let value = toolBinding(for: command)
+        let resolvedPath = model.displayPath(for: command)
+        let hasOverride = !(model.trimmedRawPath(for: command) ?? "").isEmpty
+
         return SettingRow(title: command, description: description) {
-            TextField(String.localized("Resolved automatically"), text: value)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 280)
-                .font(.system(size: 12, design: .monospaced))
-                .onChange(of: value.wrappedValue) { _, _ in
-                    hasUnappliedChanges = true
+            VStack(alignment: .trailing, spacing: 4) {
+                TextField(String.localized("Resolved automatically"), text: value)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 280)
+                    .font(.system(size: 12, design: .monospaced))
+                    .onChange(of: value.wrappedValue) { _, _ in
+                        hasUnappliedChanges = true
+                    }
+
+                if !resolvedPath.isEmpty {
+                    Text(
+                        hasOverride
+                            ? String(format: .localized("Using override: %@"), resolvedPath)
+                            : String(format: .localized("Auto-detected: %@"), resolvedPath)
+                    )
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 280, alignment: .trailing)
+                    .multilineTextAlignment(.trailing)
+                    .textSelection(.enabled)
                 }
+            }
         }
     }
 
     private func toolBinding(for command: String) -> Binding<String> {
         Binding(
             get: {
-                if let rawValue = model.trimmedRawPath(for: command), !rawValue.isEmpty {
-                    return rawValue
-                }
-                return model.displayPath(for: command)
+                model.rawPath(for: command) ?? ""
             },
             set: { newValue in
                 model.setRawPath(newValue, for: command)

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -200,6 +200,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case keyboard = "Keyboard"
     case mouse = "Mouse"
     case window = "Window"
+    case tools = "Tools"
     case network = "Network"
     case agents = "Agent Hooks"
 
@@ -218,6 +219,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .keyboard: return "keyboard"
         case .mouse: return "computermouse"
         case .window: return "macwindow"
+        case .tools: return "hammer"
         case .network: return "network"
         case .agents: return "cpu"
         }
@@ -237,6 +239,8 @@ public struct GhosttySettingsView: View {
     @Binding var proxySettings: ProxySettingsModel
     var onProxyApply: ((ProxySettingsModel) -> Void)?
     var onSystemProxyDetect: (() -> ProxySettingsModel)?
+    @Binding var toolSettings: ToolSettings
+    var onToolSettingsChanged: ((ToolSettings) -> Void)?
 
     // Key bindings
     var keyBindings: [KeyBinding]
@@ -259,6 +263,8 @@ public struct GhosttySettingsView: View {
         proxySettings: Binding<ProxySettingsModel> = .constant(ProxySettingsModel()),
         onProxyApply: ((ProxySettingsModel) -> Void)? = nil,
         onSystemProxyDetect: (() -> ProxySettingsModel)? = nil,
+        toolSettings: Binding<ToolSettings> = .constant(ToolSettings()),
+        onToolSettingsChanged: ((ToolSettings) -> Void)? = nil,
         keyBindings: [KeyBinding] = [],
         keyBindingDefaults: [KeyBinding] = [],
         onKeyBindingValidate: ((KeyBinding) -> ConflictResult)? = nil,
@@ -276,6 +282,8 @@ public struct GhosttySettingsView: View {
         self._proxySettings = proxySettings
         self.onProxyApply = onProxyApply
         self.onSystemProxyDetect = onSystemProxyDetect
+        self._toolSettings = toolSettings
+        self.onToolSettingsChanged = onToolSettingsChanged
         self.keyBindings = keyBindings
         self.keyBindingDefaults = keyBindingDefaults
         self.onKeyBindingValidate = onKeyBindingValidate
@@ -387,6 +395,10 @@ public struct GhosttySettingsView: View {
                     )
                     case .mouse: MouseSettingsContent(model: $model, onChanged: onChanged)
                     case .window: WindowSettingsContent(model: $model, onChanged: onChanged)
+                    case .tools: ToolSettingsContent(
+                        model: $toolSettings,
+                        onApply: { onToolSettingsChanged?(toolSettings) }
+                    )
                     case .network: NetworkSettingsContent(
                         model: $proxySettings,
                         onApply: { onProxyApply?(proxySettings) },
@@ -1345,6 +1357,89 @@ private struct WindowSettingsContent: View {
                     .labelsHidden()
                     .onChange(of: model.windowPaddingBalance) { _, _ in onChanged() }
             }
+        }
+    }
+}
+
+// MARK: - Tool Settings
+
+private struct ToolSettingsContent: View {
+    @Binding var model: ToolSettings
+    let onApply: () -> Void
+
+    @State private var hasUnappliedChanges = false
+
+    var body: some View {
+        Text(String.localized("Configure explicit paths for tmux, Lazygit, and Yazi. Leave a field empty to let Mori auto-detect from common install locations and your shell PATH."))
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+        SettingsCard {
+            toolRow(
+                title: "tmux",
+                description: .localized("Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux."),
+                value: $model.tmuxPath,
+                placeholder: "/opt/homebrew/bin/tmux"
+            )
+
+            CardDivider()
+
+            toolRow(
+                title: "lazygit",
+                description: .localized("Optional Git companion tool path."),
+                value: $model.lazygitPath,
+                placeholder: "/opt/homebrew/bin/lazygit"
+            )
+
+            CardDivider()
+
+            toolRow(
+                title: "yazi",
+                description: .localized("Optional file manager companion tool path."),
+                value: $model.yaziPath,
+                placeholder: "/opt/homebrew/bin/yazi"
+            )
+        }
+
+        SettingsCard {
+            HStack {
+                Button(String.localized("Apply")) {
+                    onApply()
+                    hasUnappliedChanges = false
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!hasUnappliedChanges)
+
+                if hasUnappliedChanges {
+                    Text(String.localized("Unsaved changes"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                }
+
+                Spacer()
+
+                Text(String.localized("Tool path changes apply immediately to new launches. Existing tmux clients or shells may still use earlier paths."))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func toolRow(
+        title: String,
+        description: String,
+        value: Binding<String>,
+        placeholder: String
+    ) -> some View {
+        SettingRow(title: title, description: description) {
+            TextField(placeholder, text: value)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 280)
+                .font(.system(size: 12, design: .monospaced))
+                .onChange(of: value.wrappedValue) { _, _ in
+                    hasUnappliedChanges = true
+                }
         }
     }
 }

--- a/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/GhosttySettingsView.swift
@@ -1379,8 +1379,7 @@ private struct ToolSettingsContent: View {
             toolRow(
                 title: "tmux",
                 description: .localized("Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux."),
-                value: $model.tmuxPath,
-                placeholder: .localized("Resolved automatically")
+                command: "tmux"
             )
 
             CardDivider()
@@ -1388,8 +1387,7 @@ private struct ToolSettingsContent: View {
             toolRow(
                 title: "lazygit",
                 description: .localized("Optional Git companion tool path."),
-                value: $model.lazygitPath,
-                placeholder: .localized("Resolved automatically")
+                command: "lazygit"
             )
 
             CardDivider()
@@ -1397,8 +1395,7 @@ private struct ToolSettingsContent: View {
             toolRow(
                 title: "yazi",
                 description: .localized("Optional file manager companion tool path."),
-                value: $model.yaziPath,
-                placeholder: .localized("Resolved automatically")
+                command: "yazi"
             )
         }
 
@@ -1429,11 +1426,11 @@ private struct ToolSettingsContent: View {
     private func toolRow(
         title: String,
         description: String,
-        value: Binding<String>,
-        placeholder: String
+        command: String
     ) -> some View {
-        SettingRow(title: title, description: description) {
-            TextField(placeholder, text: value)
+        let value = toolBinding(for: command)
+        return SettingRow(title: title, description: description) {
+            TextField(String.localized("Resolved automatically"), text: value)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 280)
                 .font(.system(size: 12, design: .monospaced))
@@ -1441,6 +1438,30 @@ private struct ToolSettingsContent: View {
                     hasUnappliedChanges = true
                 }
         }
+    }
+
+    private func toolBinding(for command: String) -> Binding<String> {
+        Binding(
+            get: {
+                let rawValue = model.rawPath(for: command)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if rawValue.isEmpty {
+                    return model.displayPath(for: command)
+                }
+                return rawValue
+            },
+            set: { newValue in
+                switch command {
+                case "tmux":
+                    model.tmuxPath = newValue
+                case "lazygit":
+                    model.lazygitPath = newValue
+                case "yazi":
+                    model.yaziPath = newValue
+                default:
+                    return
+                }
+            }
+        )
     }
 }
 

--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "Unassign shortcut" = "Unassign shortcut";
 "Reset" = "Reset";
 "Reset All Shortcuts" = "Reset All Shortcuts";
+"Resolved automatically" = "Resolved automatically";
 "Conflict with %@" = "Conflict with %@";
 "Assign Anyway" = "Assign Anyway";
 "Cancel" = "Cancel";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -127,6 +127,11 @@
 
 /* Network / Proxy Settings */
 "Network" = "Network";
+"Configure explicit paths for tmux, Lazygit, and Yazi. Leave a field empty to let Mori auto-detect from common install locations and your shell PATH." = "Configure explicit paths for tmux, Lazygit, and Yazi. Leave a field empty to let Mori auto-detect from common install locations and your shell PATH.";
+"Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux." = "Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux.";
+"Optional Git companion tool path." = "Optional Git companion tool path.";
+"Optional file manager companion tool path." = "Optional file manager companion tool path.";
+"Tool path changes apply immediately to new launches. Existing tmux clients or shells may still use earlier paths." = "Tool path changes apply immediately to new launches. Existing tmux clients or shells may still use earlier paths.";
 "Configure proxy environment variables for all terminal sessions. Both lowercase and uppercase variants (e.g. http_proxy and HTTP_PROXY) are set automatically." = "Configure proxy environment variables for all terminal sessions. Both lowercase and uppercase variants (e.g. http_proxy and HTTP_PROXY) are set automatically.";
 "Proxy Mode" = "Proxy Mode";
 "System proxy" = "System proxy";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -174,6 +174,8 @@
 "Reset" = "Reset";
 "Reset All Shortcuts" = "Reset All Shortcuts";
 "Resolved automatically" = "Resolved automatically";
+"Auto-detected: %@" = "Auto-detected: %@";
+"Using override: %@" = "Using override: %@";
 "Conflict with %@" = "Conflict with %@";
 "Assign Anyway" = "Assign Anyway";
 "Cancel" = "Cancel";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -174,6 +174,8 @@
 "Reset" = "重置";
 "Reset All Shortcuts" = "重置所有快捷键";
 "Resolved automatically" = "自动解析";
+"Auto-detected: %@" = "自动检测：%@";
+"Using override: %@" = "使用覆盖路径：%@";
 "Conflict with %@" = "与 %@ 冲突";
 "Assign Anyway" = "仍然分配";
 "Cancel" = "取消";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -127,6 +127,11 @@
 
 /* Network / Proxy Settings */
 "Network" = "网络";
+"Configure explicit paths for tmux, Lazygit, and Yazi. Leave a field empty to let Mori auto-detect from common install locations and your shell PATH." = "为 tmux、Lazygit 和 Yazi 配置显式路径。留空则让 Mori 从常见安装位置和你的 shell PATH 中自动检测。";
+"Required for local Mori workspaces. Supports custom installs such as ~/homebrew/bin/tmux." = "本地 Mori 工作区必需。支持 ~/homebrew/bin/tmux 这类自定义安装路径。";
+"Optional Git companion tool path." = "可选的 Git 辅助工具路径。";
+"Optional file manager companion tool path." = "可选的文件管理器辅助工具路径。";
+"Tool path changes apply immediately to new launches. Existing tmux clients or shells may still use earlier paths." = "工具路径变更会立即应用到新的启动。现有 tmux 客户端或 shell 仍可能继续使用旧路径。";
 "Configure proxy environment variables for all terminal sessions. Both lowercase and uppercase variants (e.g. http_proxy and HTTP_PROXY) are set automatically." = "为所有终端会话配置代理环境变量。小写和大写变量（如 http_proxy 和 HTTP_PROXY）会同时自动设置。";
 "Proxy Mode" = "代理模式";
 "System proxy" = "系统代理";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "Unassign shortcut" = "取消分配快捷键";
 "Reset" = "重置";
 "Reset All Shortcuts" = "重置所有快捷键";
+"Resolved automatically" = "自动解析";
 "Conflict with %@" = "与 %@ 冲突";
 "Assign Anyway" = "仍然分配";
 "Cancel" = "取消";

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -750,7 +750,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             },
             onToolSettingsChanged: { [weak self] newModel in
                 ToolSettings.save(newModel)
-                self?.terminalAreaController?.tmuxBinaryPath = TmuxCommandRunner.preferredBinaryPath() ?? "tmux"
+                Task { @MainActor [weak self] in
+                    guard let self,
+                          let manager = self.workspaceManager,
+                          let tmuxPath = try? await manager.tmuxBackend.resolvedBinaryPath() else { return }
+                    self.terminalAreaController?.tmuxBinaryPath = tmuxPath
+                }
             },
             keyBindings: store.bindings,
             keyBindingDefaults: KeyBindingDefaults.all,

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -715,6 +715,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 droidEnabled: AgentHookConfigurator.isDroidHookInstalled()
             ),
             initialProxy: ProxySettingsApplicator.load(),
+            initialTools: ToolSettings.load(),
             onChanged: { [weak self] newModel in
                 guard let self else { return }
                 self.writeSettingsModel(newModel, to: cf)
@@ -746,6 +747,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             },
             onSystemProxyDetect: {
                 ProxySettingsApplicator.readSystemProxy()
+            },
+            onToolSettingsChanged: { [weak self] newModel in
+                ToolSettings.save(newModel)
+                self?.terminalAreaController?.tmuxBinaryPath = TmuxCommandRunner.preferredBinaryPath() ?? "tmux"
             },
             keyBindings: store.bindings,
             keyBindingDefaults: KeyBindingDefaults.all,
@@ -1572,7 +1577,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 let toolId = String(actionId.dropFirst("action.tool-".count))
                 if let tool = ToolDetector.detectAll().first(where: { $0.id == toolId }) {
                     Task { @MainActor in
-                        await manager.launchToolInCurrentSession(command: tool.command, windowName: tool.name.lowercased())
+                        await manager.launchToolInCurrentSession(
+                            command: tool.command,
+                            resolvedLocalCommand: tool.resolvedCommand,
+                            windowName: tool.name.lowercased()
+                        )
                     }
                 }
             }
@@ -1727,6 +1736,7 @@ private struct SettingsWindowContent: View {
     @State var model: GhosttySettingsModel
     @State var agentHooks: AgentHookModel
     @State var proxySettings: ProxySettingsModel
+    @State var toolSettings: ToolSettings
     let availableThemes: [String]
     let ghosttyDefaults: [String]
     var onChanged: (GhosttySettingsModel) -> Void
@@ -1734,6 +1744,7 @@ private struct SettingsWindowContent: View {
     var onAgentHookChanged: (AgentHookModel) -> Void
     var onProxyApply: (ProxySettingsModel) -> Void
     var onSystemProxyDetect: (() -> ProxySettingsModel)?
+    var onToolSettingsChanged: (ToolSettings) -> Void
 
     // Key bindings
     @State var keyBindings: [KeyBinding]
@@ -1750,11 +1761,13 @@ private struct SettingsWindowContent: View {
         ghosttyDefaults: [String] = [],
         initialAgentHooks: AgentHookModel = AgentHookModel(),
         initialProxy: ProxySettingsModel = ProxySettingsModel(),
+        initialTools: ToolSettings = ToolSettings(),
         onChanged: @escaping (GhosttySettingsModel) -> Void,
         onOpenConfigFile: @escaping () -> Void,
         onAgentHookChanged: @escaping (AgentHookModel) -> Void = { _ in },
         onProxyApply: @escaping (ProxySettingsModel) -> Void = { _ in },
         onSystemProxyDetect: (() -> ProxySettingsModel)? = nil,
+        onToolSettingsChanged: @escaping (ToolSettings) -> Void = { _ in },
         keyBindings: [KeyBinding] = [],
         keyBindingDefaults: [KeyBinding] = [],
         onKeyBindingValidate: ((KeyBinding) -> ConflictResult)? = nil,
@@ -1766,6 +1779,7 @@ private struct SettingsWindowContent: View {
         self._model = State(initialValue: initial)
         self._agentHooks = State(initialValue: initialAgentHooks)
         self._proxySettings = State(initialValue: initialProxy)
+        self._toolSettings = State(initialValue: initialTools)
         self.availableThemes = availableThemes
         self.ghosttyDefaults = ghosttyDefaults
         self.onChanged = onChanged
@@ -1773,6 +1787,7 @@ private struct SettingsWindowContent: View {
         self.onAgentHookChanged = onAgentHookChanged
         self.onProxyApply = onProxyApply
         self.onSystemProxyDetect = onSystemProxyDetect
+        self.onToolSettingsChanged = onToolSettingsChanged
         self._keyBindings = State(initialValue: keyBindings)
         self.keyBindingDefaults = keyBindingDefaults
         self.onKeyBindingValidate = onKeyBindingValidate
@@ -1794,6 +1809,8 @@ private struct SettingsWindowContent: View {
             proxySettings: $proxySettings,
             onProxyApply: onProxyApply,
             onSystemProxyDetect: onSystemProxyDetect,
+            toolSettings: $toolSettings,
+            onToolSettingsChanged: onToolSettingsChanged,
             keyBindings: keyBindings,
             keyBindingDefaults: keyBindingDefaults,
             onKeyBindingValidate: onKeyBindingValidate,

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -218,7 +218,7 @@ final class TerminalAreaViewController: NSViewController {
         switch location {
         case .local:
             let escapedCwd = shellEscape(workingDirectory)
-            let command = "export STARSHIP_LOG=error; \(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
+            let command = "\(localEnvironmentExports())\(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
             attachSurface(identity: sessionKey, command: command, workingDirectory: workingDirectory)
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
@@ -246,7 +246,7 @@ final class TerminalAreaViewController: NSViewController {
         focus: Bool = true
     ) {
         let resolvedLocalCommand = BinaryResolver.resolveTool(command: command) ?? command
-        let localCommand = "export STARSHIP_LOG=error; cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
+        let localCommand = "\(localEnvironmentExports())cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
 
         switch location {
         case .local:
@@ -403,6 +403,12 @@ final class TerminalAreaViewController: NSViewController {
 
     private func shellEscape(_ str: String) -> String {
         "'" + str.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private func localEnvironmentExports() -> String {
+        let synthesizedPath = BinaryResolver.synthesizedPATH()
+        let pathExport = synthesizedPath.isEmpty ? "" : "export PATH=\(shellEscape(synthesizedPath)); "
+        return "\(pathExport)export STARSHIP_LOG=error; "
     }
 
     private func sshOptionsForInteractiveTerminal(_ ssh: SSHWorkspaceLocation) -> [String] {

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -241,10 +241,7 @@ final class TerminalAreaViewController: NSViewController {
         location: WorkspaceLocation = .local,
         focus: Bool = true
     ) {
-        let resolvedLocalCommand = BinaryResolver.resolve(
-            command: command,
-            configuredPath: ToolSettings.load().configuredPath(for: command)
-        ) ?? command
+        let resolvedLocalCommand = BinaryResolver.resolveTool(command: command) ?? command
         let localCommand = "export STARSHIP_LOG=error; cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
 
         switch location {

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -238,7 +238,11 @@ final class TerminalAreaViewController: NSViewController {
         location: WorkspaceLocation = .local,
         focus: Bool = true
     ) {
-        let localCommand = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(command)"
+        let resolvedLocalCommand = BinaryResolver.resolve(
+            command: command,
+            configuredPath: ToolSettings.load().configuredPath(for: command)
+        ) ?? command
+        let localCommand = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
 
         switch location {
         case .local:

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -218,12 +218,15 @@ final class TerminalAreaViewController: NSViewController {
         switch location {
         case .local:
             let escapedCwd = shellEscape(workingDirectory)
-            let command = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; \(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
+            let command = "export STARSHIP_LOG=error; \(escapedTmux) new-session -A -s \(escaped) -c \(escapedCwd)"
             attachSurface(identity: sessionKey, command: command, workingDirectory: workingDirectory)
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
             let remoteCwd = shellEscape(workingDirectory)
-            let remoteTmux = "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:$PATH\"; tmux new-session -A -s \(escaped) -c \(remoteCwd)"
+            let remoteTmux = remoteLoginShellCommand(
+                "tmux new-session -A -s \(escaped) -c \(remoteCwd)",
+                termProgram: termProgram
+            )
             attachSurface(identity: sessionKey, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteTmux), workingDirectory: NSHomeDirectory())
         }
     }
@@ -242,14 +245,17 @@ final class TerminalAreaViewController: NSViewController {
             command: command,
             configuredPath: ToolSettings.load().configuredPath(for: command)
         ) ?? command
-        let localCommand = "export STARSHIP_LOG=error; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
+        let localCommand = "export STARSHIP_LOG=error; cd \(shellEscape(workingDirectory)); exec \(shellEscape(resolvedLocalCommand))"
 
         switch location {
         case .local:
             attachSurface(identity: identity, command: localCommand, workingDirectory: workingDirectory, focus: focus)
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
-            let remoteCommand = "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/snap/bin:$PATH\"; cd \(shellEscape(workingDirectory)); exec \(command)"
+            let remoteCommand = remoteLoginShellCommand(
+                "cd \(shellEscape(workingDirectory)); exec \(command)",
+                termProgram: termProgram
+            )
             attachSurface(identity: identity, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteCommand), workingDirectory: NSHomeDirectory(), focus: focus)
         }
     }
@@ -461,6 +467,11 @@ final class TerminalAreaViewController: NSViewController {
         }
         sshCommand += " \(shellEscape(ssh.target)) \(shellEscape(remoteCommand))"
         return sshCommand
+    }
+
+    private func remoteLoginShellCommand(_ command: String, termProgram: String) -> String {
+        let shell = "${SHELL:-/bin/sh}"
+        return "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; exec \(shell) -l -c \(shellEscape(command))"
     }
 
     /// Defensive cleanup in case a dead surface view was not tracked as current.

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -223,9 +223,13 @@ final class TerminalAreaViewController: NSViewController {
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
             let remoteCwd = shellEscape(workingDirectory)
-            let remoteTmux = remoteLoginShellCommand(
+            let remoteTmux = SSHCommandSupport.remoteLoginShellCommand(
                 "tmux new-session -A -s \(escaped) -c \(remoteCwd)",
-                termProgram: termProgram
+                environment: [
+                    "STARSHIP_LOG": "error",
+                    "TERM_PROGRAM": termProgram,
+                    "COLORTERM": "truecolor",
+                ]
             )
             attachSurface(identity: sessionKey, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteTmux), workingDirectory: NSHomeDirectory())
         }
@@ -249,9 +253,13 @@ final class TerminalAreaViewController: NSViewController {
             attachSurface(identity: identity, command: localCommand, workingDirectory: workingDirectory, focus: focus)
         case .ssh(let ssh):
             let termProgram = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? "ghostty"
-            let remoteCommand = remoteLoginShellCommand(
+            let remoteCommand = SSHCommandSupport.remoteLoginShellCommand(
                 "cd \(shellEscape(workingDirectory)); exec \(command)",
-                termProgram: termProgram
+                environment: [
+                    "STARSHIP_LOG": "error",
+                    "TERM_PROGRAM": termProgram,
+                    "COLORTERM": "truecolor",
+                ]
             )
             attachSurface(identity: identity, command: wrappedSSHCommand(ssh: ssh, remoteCommand: remoteCommand), workingDirectory: NSHomeDirectory(), focus: focus)
         }
@@ -466,10 +474,6 @@ final class TerminalAreaViewController: NSViewController {
         return sshCommand
     }
 
-    private func remoteLoginShellCommand(_ command: String, termProgram: String) -> String {
-        let shell = "${SHELL:-/bin/sh}"
-        return "export STARSHIP_LOG=error; export TERM_PROGRAM=\(shellEscape(termProgram)); export COLORTERM=truecolor; exec \(shell) -l -c \(shellEscape(command))"
-    }
 
     /// Defensive cleanup in case a dead surface view was not tracked as current.
     private func removeResidualTerminalSubviews() {

--- a/Sources/Mori/App/ToolDetector.swift
+++ b/Sources/Mori/App/ToolDetector.swift
@@ -25,9 +25,9 @@ struct ToolDetector: Sendable {
     static func detectAll() -> [Tool] {
         let settings = ToolSettings.load()
         return knownTools.map { tool in
-            let resolvedCommand = BinaryResolver.resolve(
+            let resolvedCommand = BinaryResolver.resolveTool(
                 command: tool.command,
-                configuredPath: settings.configuredPath(for: tool.command)
+                settings: settings
             )
             let available = resolvedCommand != nil
             return Tool(

--- a/Sources/Mori/App/ToolDetector.swift
+++ b/Sources/Mori/App/ToolDetector.swift
@@ -1,6 +1,8 @@
 import Foundation
+import MoriCore
 
-/// Detects availability of external CLI tools (lazygit, yazi, etc.) via PATH lookup.
+/// Detects availability of external CLI tools (lazygit, yazi, etc.) via configured
+/// paths, common package-manager prefixes, and PATH lookup.
 struct ToolDetector: Sendable {
 
     /// A CLI tool that Mori can launch in a tmux pane.
@@ -10,6 +12,7 @@ struct ToolDetector: Sendable {
         let command: String
         let description: String
         let isAvailable: Bool
+        let resolvedCommand: String?
     }
 
     /// Well-known tools that Mori can detect and offer to launch.
@@ -20,31 +23,21 @@ struct ToolDetector: Sendable {
 
     /// Detect all known tools and return their availability status.
     static func detectAll() -> [Tool] {
-        knownTools.map { tool in
-            let available = isInPath(tool.command)
+        let settings = ToolSettings.load()
+        return knownTools.map { tool in
+            let resolvedCommand = BinaryResolver.resolve(
+                command: tool.command,
+                configuredPath: settings.configuredPath(for: tool.command)
+            )
+            let available = resolvedCommand != nil
             return Tool(
                 id: tool.id,
                 name: tool.name,
                 command: tool.command,
                 description: available ? tool.description : "Not installed — \(tool.installHint)",
-                isAvailable: available
+                isAvailable: available,
+                resolvedCommand: resolvedCommand
             )
-        }
-    }
-
-    /// Check if a command exists in PATH.
-    private static func isInPath(_ command: String) -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        process.arguments = [command]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus == 0
-        } catch {
-            return false
         }
     }
 }

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -1898,10 +1898,15 @@ final class WorkspaceManager {
     }
 
     /// Launch a CLI tool in the currently selected worktree's tmux session.
-    func launchToolInCurrentSession(command: String, windowName: String) async {
+    func launchToolInCurrentSession(
+        command: String,
+        resolvedLocalCommand: String? = nil,
+        windowName: String
+    ) async {
         guard let worktree = appState.selectedWorktree,
               let sessionName = worktree.tmuxSessionName else { return }
         let tmux = tmuxBackend(for: worktree)
+        let launchCommand = location(for: worktree) == .local ? (resolvedLocalCommand ?? command) : command
         do {
             let newWindow = try await tmux.createWindow(
                 sessionId: sessionName,
@@ -1911,7 +1916,7 @@ final class WorkspaceManager {
             try await tmux.sendKeys(
                 sessionId: sessionName,
                 paneId: newWindow.windowId,
-                keys: command
+                keys: launchCommand
             )
             await refreshRuntimeState()
         } catch {
@@ -1997,12 +2002,19 @@ final class WorkspaceManager {
 
         // Resolve cwd from the active pane, falling back to worktree path
         let cwd = activePaneCwd() ?? worktree.path
+        let resolvedLocalCommand = location(for: worktree) == .local
+            ? BinaryResolver.resolve(
+                command: command,
+                configuredPath: ToolSettings.load().configuredPath(for: command)
+            )
+            : nil
+        let launchCommand = resolvedLocalCommand ?? command
 
         do {
             let sessionReady = await ensureTmuxSession(for: worktree, showErrors: true)
             guard sessionReady else { return }
             let window = try await tmux.createWindow(sessionId: sessionName, name: command, cwd: cwd)
-            try await tmux.sendKeys(sessionId: sessionName, paneId: window.windowId, keys: command)
+            try await tmux.sendKeys(sessionId: sessionName, paneId: window.windowId, keys: launchCommand)
             await refreshRuntimeState()
             onTerminalSwitch?(sessionName, worktree.path, location(for: worktree))
         } catch {

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -1906,7 +1906,11 @@ final class WorkspaceManager {
         guard let worktree = appState.selectedWorktree,
               let sessionName = worktree.tmuxSessionName else { return }
         let tmux = tmuxBackend(for: worktree)
-        let launchCommand = location(for: worktree) == .local ? (resolvedLocalCommand ?? command) : command
+        let launchCommand = toolLaunchCommand(
+            command: command,
+            resolvedLocalCommand: resolvedLocalCommand,
+            location: location(for: worktree)
+        )
         do {
             let newWindow = try await tmux.createWindow(
                 sessionId: sessionName,
@@ -2002,10 +2006,15 @@ final class WorkspaceManager {
 
         // Resolve cwd from the active pane, falling back to worktree path
         let cwd = activePaneCwd() ?? worktree.path
-        let resolvedLocalCommand = location(for: worktree) == .local
+        let workspaceLocation = location(for: worktree)
+        let resolvedLocalCommand = workspaceLocation == .local
             ? BinaryResolver.resolveTool(command: command)
             : nil
-        let launchCommand = resolvedLocalCommand ?? command
+        let launchCommand = toolLaunchCommand(
+            command: command,
+            resolvedLocalCommand: resolvedLocalCommand,
+            location: workspaceLocation
+        )
 
         do {
             let sessionReady = await ensureTmuxSession(for: worktree, showErrors: true)
@@ -2028,6 +2037,19 @@ final class WorkspaceManager {
         guard let windowId = appState.uiState.selectedWindowId else { return nil }
         let panes = appState.panes(forWindow: windowId)
         return panes.first(where: { $0.isActive })?.cwd ?? panes.first?.cwd
+    }
+
+    private func toolLaunchCommand(
+        command: String,
+        resolvedLocalCommand: String?,
+        location: WorkspaceLocation
+    ) -> String {
+        switch location {
+        case .local:
+            return SSHCommandSupport.shellEscape(resolvedLocalCommand ?? command)
+        case .ssh:
+            return command
+        }
     }
 
     // MARK: - Pane Navigation & Management

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -2003,10 +2003,7 @@ final class WorkspaceManager {
         // Resolve cwd from the active pane, falling back to worktree path
         let cwd = activePaneCwd() ?? worktree.path
         let resolvedLocalCommand = location(for: worktree) == .local
-            ? BinaryResolver.resolve(
-                command: command,
-                configuredPath: ToolSettings.load().configuredPath(for: command)
-            )
+            ? BinaryResolver.resolveTool(command: command)
             : nil
         let launchCommand = resolvedLocalCommand ?? command
 

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -2046,7 +2046,10 @@ final class WorkspaceManager {
     ) -> String {
         switch location {
         case .local:
-            return SSHCommandSupport.shellEscape(resolvedLocalCommand ?? command)
+            let executable = SSHCommandSupport.shellEscape(resolvedLocalCommand ?? command)
+            let pathValue = BinaryResolver.synthesizedPATH()
+            let pathExport = pathValue.isEmpty ? "" : "export PATH=\(SSHCommandSupport.shellEscape(pathValue)); "
+            return "\(pathExport)exec \(executable)"
         case .ssh:
             return command
         }


### PR DESCRIPTION
## Summary
- add shared binary resolution for tmux, lazygit, and yazi
- persist explicit tool path overrides in Settings > Tools
- use resolved local executable paths when launching companion tools and tmux-backed flows

## Why
Issue #54 reports Mori failing to detect tmux installed in a custom Homebrew prefix like `~/homebrew/bin/tmux`. The root problem was broader than tmux availability: different code paths used different PATH assumptions, and local launches for tmux/lazygit/yazi still depended on the app's inherited environment.

This change introduces a single resolver with explicit user overrides, common package-manager fallback directories, and PATH lookup, then applies it consistently across tmux detection and local tool launching.

## Changes
- add `ToolSettings` persistence in `MoriCore`
- add shared `BinaryResolver` in `MoriCore`
- update `TmuxCommandRunner` to use configured paths + shared resolution
- add `Settings > Tools` UI for tmux/lazygit/yazi path overrides
- update local tool detection to use the shared resolver instead of `/usr/bin/which`
- update local command launches to use resolved executable paths
- add tests for tool settings + binary resolution
- update changelog and localizations

## Validation
- `mise run test:core`
- `mise run test:tmux`
- `mise run test`
- `swift build -c release --product Mori`

Closes #54
