### PR TITLE
Fix key bar gesture recognizer crash

### DIFF
--- a/MoriRemote/MoriRemote/Accessories/KeyBarView.swift
+++ b/MoriRemote/MoriRemote/Accessories/KeyBarView.swift
@@ -60,6 +60,7 @@ final class KeyBarView: UIView {
 
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
+        scrollView.delaysContentTouches = false
         scrollView.delegate = self
         scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -178,6 +179,7 @@ final class KeyBarView: UIView {
         button.layer.borderColor = keyBorder.cgColor
         button.clipsToBounds = true
         button.adjustsImageWhenHighlighted = false
+        button.isExclusiveTouch = true
 
         let isArrow = action.iconName != nil
         let minWidth: CGFloat = isArrow ? 28 : 34


### PR DESCRIPTION
## Summary

- Fix a UIKit crash (`insertObject:atIndex: object cannot be nil`) triggered when pressing key bar buttons (most commonly ESC)
- Set `delaysContentTouches = false` on the scroll view so buttons respond immediately without gesture conflict
- Set `isExclusiveTouch = true` on key buttons to prevent multi-touch gesture conflicts

## Crash Stack

```
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  frame #10: CoreFoundation`-[__NSArrayM insertObject:atIndex:] + 1864
  frame #11: UIKitCore`-[UIGestureRecognizer _delayTouchesForEvent:inPhase:] + 312
  frame #12: UIKitCore`-[UIGestureRecognizer _delayTouchesForEventIfNeeded:] + 64
  frame #13: UIKitCore`-[UIGestureRecognizer _delayActiveEventsToRespondersIfNeeded] + 60
  frame #14: UIKitCore`-[UIGestureEnvironment _updateForEvent:window:] + 700
  frame #15: UIKitCore`-[UIWindow sendEvent:] + 3540
```

## Root Cause

The scroll view's pan gesture recognizer delays touch events to determine if the user is scrolling or tapping. During this delay, UIKit internally tries to insert a touch object into an array, but the object is nil — causing the crash. This is a known UIKit edge case with buttons inside scroll views used as input accessory views.

## Test plan

- [ ] Press ESC button repeatedly on key bar — no crash
- [ ] Press other key bar buttons rapidly — no crash
- [ ] Scroll the key bar horizontally — still works
- [ ] Multi-touch on key bar buttons — no crash