### PR TITLE
✨ feat: Cmd-hold shortcut hints for toolbar & sidebar footer

### DIFF
--- a/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/en.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "Active" = "Active";
 "Active window" = "Active window";
 "Add Project" = "Add Project";
-"Add Repository" = "Add Repository";
+"Open Project (⇧⌘O)" = "Open Project (⇧⌘O)";
 "Adds a notify entry to ~/.codex/config.toml for agent turn completion events." = "Adds a notify entry to ~/.codex/config.toml for agent turn completion events.";
 "Adds hooks to ~/.claude/settings.json for prompt submit, tool use, stop, and notification events." = "Adds hooks to ~/.claude/settings.json for prompt submit, tool use, stop, and notification events.";
 "Agent" = "Agent";

--- a/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/MoriUI/Sources/MoriUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "Active" = "活跃";
 "Active window" = "活跃窗口";
 "Add Project" = "添加项目";
-"Add Repository" = "添加仓库";
+"Open Project (⇧⌘O)" = "打开项目 (⇧⌘O)";
 "Adds a notify entry to ~/.codex/config.toml for agent turn completion events." = "向 ~/.codex/config.toml 添加通知条目，用于代理回合完成事件。";
 "Adds hooks to ~/.claude/settings.json for prompt submit, tool use, stop, and notification events." = "向 ~/.claude/settings.json 添加钩子，用于提示提交、工具使用、停止和通知事件。";
 "Agent" = "代理";

--- a/Packages/MoriUI/Sources/MoriUI/SidebarFooterView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/SidebarFooterView.swift
@@ -82,7 +82,7 @@ struct SidebarFooterView: View {
     ) -> some View {
         Button(action: action) {
             Image(systemName: systemImage)
-                .font(.system(size: 13))
+                .font(.system(size: 13, weight: .regular))
                 .foregroundStyle(MoriTokens.Color.muted)
         }
         .buttonStyle(.plain)

--- a/Packages/MoriUI/Sources/MoriUI/SidebarFooterView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/SidebarFooterView.swift
@@ -29,8 +29,9 @@ struct SidebarFooterView: View {
                 if let onAddProject {
                     footerButton(
                         systemImage: "plus.rectangle.on.folder",
-                        helpText: String.localized("Add Repository"),
-                        accessibilityLabel: String.localized("Add Repository"),
+                        helpText: String.localized("Open Project (⇧⌘O)"),
+                        accessibilityLabel: String.localized("Open Project"),
+                        shortcutHint: "⇧⌘O",
                         action: onAddProject
                     )
                 }

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -207,17 +207,20 @@ final class MainWindowController: NSWindowController {
         for (id, hint) in Self.toolbarShortcutHints {
             guard let anchor = toolbarButtonViews[id], anchor.window != nil else { continue }
 
+            // Convert button rect to themeFrame coords (bottom-left origin).
             let anchorRect = anchor.convert(anchor.bounds, to: themeFrame)
 
             let pill = NSHostingView(rootView: ShortcutHintPill(hint))
-            pill.translatesAutoresizingMaskIntoConstraints = false
-            themeFrame.addSubview(pill)
+            let pillSize = pill.fittingSize
 
-            // Center horizontally on the button, position above it.
-            NSLayoutConstraint.activate([
-                pill.centerXAnchor.constraint(equalTo: themeFrame.leadingAnchor, constant: anchorRect.midX),
-                pill.topAnchor.constraint(equalTo: themeFrame.topAnchor, constant: anchorRect.maxY + 2),
-            ])
+            // Center horizontally on the button, position above it (y increases upward).
+            pill.frame = NSRect(
+                x: anchorRect.midX - pillSize.width / 2,
+                y: anchorRect.maxY + 2,
+                width: pillSize.width,
+                height: pillSize.height
+            )
+            themeFrame.addSubview(pill)
 
             pill.alphaValue = 0
             shortcutHintOverlays.append(pill)

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -1,6 +1,8 @@
 import AppKit
+import Combine
 import SwiftUI
 import MoriTerminal
+import MoriUI
 
 final class MainWindowController: NSWindowController {
     var onWindowAppearanceInvalidated: (() -> Void)?
@@ -16,6 +18,15 @@ final class MainWindowController: NSWindowController {
         static let splitDown = NSToolbarItem.Identifier("splitDown")
     }
 
+    /// Maps toolbar item identifiers to their shortcut hint strings.
+    private static let toolbarShortcutHints: [NSToolbarItem.Identifier: String] = [
+        ToolbarID.toggleSidebar: "⌘B",
+        ToolbarID.files: "⌘E",
+        ToolbarID.git: "⌘G",
+        ToolbarID.splitRight: "⌘D",
+        ToolbarID.splitDown: "⇧⌘D",
+    ]
+
     var onToggleSidebar: (() -> Void)?
     var onToggleFiles: (() -> Void)?
     var onToggleGit: (() -> Void)?
@@ -25,6 +36,12 @@ final class MainWindowController: NSWindowController {
 
     /// The hosting view for the update pill, overlaid on the titlebar.
     private var updateOverlay: NSView?
+
+    // MARK: - Shortcut Hints
+
+    private let shortcutHintMonitor = ShortcutHintModifierMonitor()
+    private var shortcutHintCancellable: AnyCancellable?
+    private var shortcutHintOverlays: [NSView] = []
 
     // MARK: - Init
 
@@ -47,6 +64,7 @@ final class MainWindowController: NSWindowController {
 
         window.delegate = self
         configureToolbar()
+        startShortcutHintMonitor()
     }
 
     @available(*, unavailable)
@@ -134,6 +152,68 @@ final class MainWindowController: NSWindowController {
     @objc private func splitDownClicked() {
         onSplitDown?()
     }
+
+    // MARK: - Shortcut Hint Overlays
+
+    private func startShortcutHintMonitor() {
+        shortcutHintMonitor.start()
+        shortcutHintCancellable = shortcutHintMonitor.$areHintsVisible
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] visible in
+                if visible {
+                    self?.showToolbarShortcutHints()
+                } else {
+                    self?.hideToolbarShortcutHints()
+                }
+            }
+    }
+
+    private func showToolbarShortcutHints() {
+        guard let toolbar = window?.toolbar else { return }
+
+        for item in toolbar.items {
+            guard let hint = Self.toolbarShortcutHints[item.itemIdentifier],
+                  let itemView = item.value(forKey: "view") as? NSView else { continue }
+
+            let pill = NSHostingView(rootView: ShortcutHintPill(hint))
+            pill.translatesAutoresizingMaskIntoConstraints = false
+            itemView.addSubview(pill)
+            NSLayoutConstraint.activate([
+                pill.centerXAnchor.constraint(equalTo: itemView.centerXAnchor),
+                pill.bottomAnchor.constraint(equalTo: itemView.topAnchor, constant: 2),
+            ])
+            pill.alphaValue = 0
+            shortcutHintOverlays.append(pill)
+        }
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.14
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            for overlay in shortcutHintOverlays {
+                overlay.animator().alphaValue = 1
+            }
+        }
+    }
+
+    private func hideToolbarShortcutHints() {
+        let overlays = shortcutHintOverlays
+        shortcutHintOverlays.removeAll()
+
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.14
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            for overlay in overlays {
+                overlay.animator().alphaValue = 0
+            }
+        }, completionHandler: {
+            Task { @MainActor in
+                for overlay in overlays {
+                    overlay.removeFromSuperview()
+                }
+            }
+        })
+    }
 }
 
 // MARK: - NSToolbarDelegate
@@ -192,7 +272,7 @@ extension MainWindowController: NSToolbarDelegate {
         case ToolbarID.toggleSidebar:
             item.label = .localized("Toggle Sidebar")
             item.paletteLabel = .localized("Toggle Sidebar")
-            item.toolTip = .localized("Show or hide the sidebar (⌘0)")
+            item.toolTip = .localized("Show or hide the sidebar (⌘B)")
             item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))
             item.target = self
             item.action = #selector(toggleSidebarClicked)
@@ -216,7 +296,7 @@ extension MainWindowController: NSToolbarDelegate {
         case ToolbarID.splitRight:
             item.label = .localized("Split Right")
             item.paletteLabel = .localized("Split Right")
-            item.toolTip = .localized("Split the current pane to the right")
+            item.toolTip = .localized("Split the current pane to the right (⌘D)")
             item.image = NSImage(
                 systemSymbolName: "rectangle.split.2x1",
                 accessibilityDescription: .localized("Split Right")
@@ -227,7 +307,7 @@ extension MainWindowController: NSToolbarDelegate {
         case ToolbarID.splitDown:
             item.label = .localized("Split Down")
             item.paletteLabel = .localized("Split Down")
-            item.toolTip = .localized("Split the current pane downward")
+            item.toolTip = .localized("Split the current pane downward (⇧⌘D)")
             item.image = NSImage(
                 systemSymbolName: "rectangle.split.1x2",
                 accessibilityDescription: .localized("Split Down")

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -43,6 +43,9 @@ final class MainWindowController: NSWindowController {
     private var shortcutHintCancellable: AnyCancellable?
     private var shortcutHintOverlays: [NSView] = []
 
+    /// Retained references to toolbar button views keyed by item identifier.
+    private var toolbarButtonViews: [NSToolbarItem.Identifier: NSView] = [:]
+
     // MARK: - Init
 
     init(themeInfo: GhosttyThemeInfo = .fallback) {
@@ -133,6 +136,33 @@ final class MainWindowController: NSWindowController {
         window?.toolbarStyle = .unifiedCompact
     }
 
+    private static let symbolConfig = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
+
+    private func makeToolbarItem(
+        id: NSToolbarItem.Identifier,
+        label: String,
+        toolTip: String,
+        systemImageName: String,
+        action: Selector
+    ) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: id)
+        item.label = label
+        item.paletteLabel = label
+        item.toolTip = toolTip
+
+        let image = NSImage(systemSymbolName: systemImageName, accessibilityDescription: label)?
+            .withSymbolConfiguration(Self.symbolConfig) ?? NSImage()
+
+        let button = NSButton(image: image, target: self, action: action)
+        button.bezelStyle = .toolbar
+        button.imagePosition = .imageOnly
+        button.setAccessibilityLabel(label)
+
+        item.view = button
+        toolbarButtonViews[id] = button
+        return item
+    }
+
     @objc private func toggleSidebarClicked() {
         onToggleSidebar?()
     }
@@ -170,31 +200,25 @@ final class MainWindowController: NSWindowController {
     }
 
     private func showToolbarShortcutHints() {
-        guard let toolbar = window?.toolbar else { return }
+        hideToolbarShortcutHints()
+        guard let themeFrame = window?.contentView?.superview else { return }
+        themeFrame.layoutSubtreeIfNeeded()
 
-        for item in toolbar.items {
-            guard let hint = Self.toolbarShortcutHints[item.itemIdentifier] else { continue }
+        for (id, hint) in Self.toolbarShortcutHints {
+            guard let anchor = toolbarButtonViews[id], anchor.window != nil else { continue }
 
-            // Resolve the toolbar item's rendered view: custom `view` or the internal button.
-            let itemView: NSView
-            if let custom = item.view {
-                itemView = custom
-            } else if let internal_ = toolbarItemButton(for: item) {
-                itemView = internal_
-            } else {
-                continue
-            }
+            let anchorRect = anchor.convert(anchor.bounds, to: themeFrame)
 
             let pill = NSHostingView(rootView: ShortcutHintPill(hint))
             pill.translatesAutoresizingMaskIntoConstraints = false
+            themeFrame.addSubview(pill)
 
-            // Add to the item view's superview so it can appear above the button.
-            guard let parent = itemView.superview else { continue }
-            parent.addSubview(pill)
+            // Center horizontally on the button, position above it.
             NSLayoutConstraint.activate([
-                pill.centerXAnchor.constraint(equalTo: itemView.centerXAnchor),
-                pill.bottomAnchor.constraint(equalTo: itemView.topAnchor, constant: 2),
+                pill.centerXAnchor.constraint(equalTo: themeFrame.leadingAnchor, constant: anchorRect.midX),
+                pill.topAnchor.constraint(equalTo: themeFrame.topAnchor, constant: anchorRect.maxY + 2),
             ])
+
             pill.alphaValue = 0
             shortcutHintOverlays.append(pill)
         }
@@ -208,29 +232,10 @@ final class MainWindowController: NSWindowController {
         }
     }
 
-    /// Finds the system-created button view for an image-based NSToolbarItem
-    /// by matching the accessibility identifier in the toolbar view hierarchy.
-    private func toolbarItemButton(for item: NSToolbarItem) -> NSView? {
-        guard let themeFrame = window?.contentView?.superview else { return nil }
-        return findToolbarButton(in: themeFrame, identifier: item.itemIdentifier.rawValue)
-    }
-
-    private func findToolbarButton(in view: NSView, identifier: String) -> NSView? {
-        // NSToolbarItemViewer sets its identifier to the toolbar item's identifier
-        if let viewId = view.identifier?.rawValue, viewId == identifier {
-            return view
-        }
-        for subview in view.subviews {
-            if let found = findToolbarButton(in: subview, identifier: identifier) {
-                return found
-            }
-        }
-        return nil
-    }
-
     private func hideToolbarShortcutHints() {
         let overlays = shortcutHintOverlays
         shortcutHintOverlays.removeAll()
+        guard !overlays.isEmpty else { return }
 
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.14
@@ -248,7 +253,7 @@ final class MainWindowController: NSWindowController {
     }
 }
 
-// MARK: - NSToolbarDelegate
+// MARK: - NSWindowDelegate
 
 extension MainWindowController: NSWindowDelegate {
     func windowDidEnterFullScreen(_ notification: Notification) {
@@ -267,6 +272,8 @@ extension MainWindowController: NSWindowDelegate {
         onWindowAppearanceInvalidated?()
     }
 }
+
+// MARK: - NSToolbarDelegate
 
 extension MainWindowController: NSToolbarDelegate {
 
@@ -297,55 +304,47 @@ extension MainWindowController: NSToolbarDelegate {
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
-        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-        let symbolConfig = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
-
         switch itemIdentifier {
         case ToolbarID.toggleSidebar:
-            item.label = .localized("Toggle Sidebar")
-            item.paletteLabel = .localized("Toggle Sidebar")
-            item.toolTip = .localized("Show or hide the sidebar (⌘B)")
-            item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))?
-                .withSymbolConfiguration(symbolConfig)
-            item.target = self
-            item.action = #selector(toggleSidebarClicked)
-            return item
+            return makeToolbarItem(
+                id: ToolbarID.toggleSidebar,
+                label: .localized("Toggle Sidebar"),
+                toolTip: .localized("Show or hide the sidebar (⌘B)"),
+                systemImageName: "sidebar.left",
+                action: #selector(toggleSidebarClicked)
+            )
         case ToolbarID.files:
-            item.label = .localized("Files")
-            item.paletteLabel = .localized("Files")
-            item.toolTip = .localized("Open Files Companion Pane (⌘E)")
-            item.image = NSImage(systemSymbolName: "folder", accessibilityDescription: .localized("Files"))?
-                .withSymbolConfiguration(symbolConfig)
-            item.target = self
-            item.action = #selector(toggleFilesClicked)
-            return item
+            return makeToolbarItem(
+                id: ToolbarID.files,
+                label: .localized("Files"),
+                toolTip: .localized("Open Files Companion Pane (⌘E)"),
+                systemImageName: "folder",
+                action: #selector(toggleFilesClicked)
+            )
         case ToolbarID.git:
-            item.label = .localized("Git")
-            item.paletteLabel = .localized("Git")
-            item.toolTip = .localized("Open Git Companion Pane (⌘G)")
-            item.image = NSImage(systemSymbolName: "point.topleft.down.curvedto.point.bottomright.up", accessibilityDescription: .localized("Git"))?
-                .withSymbolConfiguration(symbolConfig)
-            item.target = self
-            item.action = #selector(toggleGitClicked)
-            return item
+            return makeToolbarItem(
+                id: ToolbarID.git,
+                label: .localized("Git"),
+                toolTip: .localized("Open Git Companion Pane (⌘G)"),
+                systemImageName: "point.topleft.down.curvedto.point.bottomright.up",
+                action: #selector(toggleGitClicked)
+            )
         case ToolbarID.splitRight:
-            item.label = .localized("Split Right")
-            item.paletteLabel = .localized("Split Right")
-            item.toolTip = .localized("Split the current pane to the right (⌘D)")
-            item.image = NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: .localized("Split Right"))?
-                .withSymbolConfiguration(symbolConfig)
-            item.target = self
-            item.action = #selector(splitRightClicked)
-            return item
+            return makeToolbarItem(
+                id: ToolbarID.splitRight,
+                label: .localized("Split Right"),
+                toolTip: .localized("Split the current pane to the right (⌘D)"),
+                systemImageName: "rectangle.split.2x1",
+                action: #selector(splitRightClicked)
+            )
         case ToolbarID.splitDown:
-            item.label = .localized("Split Down")
-            item.paletteLabel = .localized("Split Down")
-            item.toolTip = .localized("Split the current pane downward (⇧⌘D)")
-            item.image = NSImage(systemSymbolName: "rectangle.split.1x2", accessibilityDescription: .localized("Split Down"))?
-                .withSymbolConfiguration(symbolConfig)
-            item.target = self
-            item.action = #selector(splitDownClicked)
-            return item
+            return makeToolbarItem(
+                id: ToolbarID.splitDown,
+                label: .localized("Split Down"),
+                toolTip: .localized("Split the current pane downward (⇧⌘D)"),
+                systemImageName: "rectangle.split.1x2",
+                action: #selector(splitDownClicked)
+            )
         default:
             return nil
         }

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -266,14 +266,15 @@ extension MainWindowController: NSToolbarDelegate {
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
         let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-        let compactSplitSymbolConfiguration = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        let symbolConfig = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
 
         switch itemIdentifier {
         case ToolbarID.toggleSidebar:
             item.label = .localized("Toggle Sidebar")
             item.paletteLabel = .localized("Toggle Sidebar")
             item.toolTip = .localized("Show or hide the sidebar (⌘B)")
-            item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))
+            item.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: .localized("Toggle Sidebar"))?
+                .withSymbolConfiguration(symbolConfig)
             item.target = self
             item.action = #selector(toggleSidebarClicked)
             return item
@@ -281,7 +282,8 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Files")
             item.paletteLabel = .localized("Files")
             item.toolTip = .localized("Open Files Companion Pane (⌘E)")
-            item.image = NSImage(systemSymbolName: "folder", accessibilityDescription: .localized("Files"))
+            item.image = NSImage(systemSymbolName: "folder", accessibilityDescription: .localized("Files"))?
+                .withSymbolConfiguration(symbolConfig)
             item.target = self
             item.action = #selector(toggleFilesClicked)
             return item
@@ -289,7 +291,8 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Git")
             item.paletteLabel = .localized("Git")
             item.toolTip = .localized("Open Git Companion Pane (⌘G)")
-            item.image = NSImage(systemSymbolName: "point.topleft.down.curvedto.point.bottomright.up", accessibilityDescription: .localized("Git"))
+            item.image = NSImage(systemSymbolName: "point.topleft.down.curvedto.point.bottomright.up", accessibilityDescription: .localized("Git"))?
+                .withSymbolConfiguration(symbolConfig)
             item.target = self
             item.action = #selector(toggleGitClicked)
             return item
@@ -297,10 +300,8 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Split Right")
             item.paletteLabel = .localized("Split Right")
             item.toolTip = .localized("Split the current pane to the right (⌘D)")
-            item.image = NSImage(
-                systemSymbolName: "rectangle.split.2x1",
-                accessibilityDescription: .localized("Split Right")
-            )?.withSymbolConfiguration(compactSplitSymbolConfiguration)
+            item.image = NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: .localized("Split Right"))?
+                .withSymbolConfiguration(symbolConfig)
             item.target = self
             item.action = #selector(splitRightClicked)
             return item
@@ -308,10 +309,8 @@ extension MainWindowController: NSToolbarDelegate {
             item.label = .localized("Split Down")
             item.paletteLabel = .localized("Split Down")
             item.toolTip = .localized("Split the current pane downward (⇧⌘D)")
-            item.image = NSImage(
-                systemSymbolName: "rectangle.split.1x2",
-                accessibilityDescription: .localized("Split Down")
-            )?.withSymbolConfiguration(compactSplitSymbolConfiguration)
+            item.image = NSImage(systemSymbolName: "rectangle.split.1x2", accessibilityDescription: .localized("Split Down"))?
+                .withSymbolConfiguration(symbolConfig)
             item.target = self
             item.action = #selector(splitDownClicked)
             return item

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -173,12 +173,24 @@ final class MainWindowController: NSWindowController {
         guard let toolbar = window?.toolbar else { return }
 
         for item in toolbar.items {
-            guard let hint = Self.toolbarShortcutHints[item.itemIdentifier],
-                  let itemView = item.value(forKey: "view") as? NSView else { continue }
+            guard let hint = Self.toolbarShortcutHints[item.itemIdentifier] else { continue }
+
+            // Resolve the toolbar item's rendered view: custom `view` or the internal button.
+            let itemView: NSView
+            if let custom = item.view {
+                itemView = custom
+            } else if let internal_ = toolbarItemButton(for: item) {
+                itemView = internal_
+            } else {
+                continue
+            }
 
             let pill = NSHostingView(rootView: ShortcutHintPill(hint))
             pill.translatesAutoresizingMaskIntoConstraints = false
-            itemView.addSubview(pill)
+
+            // Add to the item view's superview so it can appear above the button.
+            guard let parent = itemView.superview else { continue }
+            parent.addSubview(pill)
             NSLayoutConstraint.activate([
                 pill.centerXAnchor.constraint(equalTo: itemView.centerXAnchor),
                 pill.bottomAnchor.constraint(equalTo: itemView.topAnchor, constant: 2),
@@ -194,6 +206,26 @@ final class MainWindowController: NSWindowController {
                 overlay.animator().alphaValue = 1
             }
         }
+    }
+
+    /// Finds the system-created button view for an image-based NSToolbarItem
+    /// by matching the accessibility identifier in the toolbar view hierarchy.
+    private func toolbarItemButton(for item: NSToolbarItem) -> NSView? {
+        guard let themeFrame = window?.contentView?.superview else { return nil }
+        return findToolbarButton(in: themeFrame, identifier: item.itemIdentifier.rawValue)
+    }
+
+    private func findToolbarButton(in view: NSView, identifier: String) -> NSView? {
+        // NSToolbarItemViewer sets its identifier to the toolbar item's identifier
+        if let viewId = view.identifier?.rawValue, viewId == identifier {
+            return view
+        }
+        for subview in view.subviews {
+            if let found = findToolbarButton(in: subview, identifier: identifier) {
+                return found
+            }
+        }
+        return nil
     }
 
     private func hideToolbarShortcutHints() {

--- a/Sources/Mori/App/MainWindowController.swift
+++ b/Sources/Mori/App/MainWindowController.swift
@@ -18,13 +18,31 @@ final class MainWindowController: NSWindowController {
         static let splitDown = NSToolbarItem.Identifier("splitDown")
     }
 
-    /// Maps toolbar item identifiers to their shortcut hint strings.
-    private static let toolbarShortcutHints: [NSToolbarItem.Identifier: String] = [
-        ToolbarID.toggleSidebar: "⌘B",
-        ToolbarID.files: "⌘E",
-        ToolbarID.git: "⌘G",
-        ToolbarID.splitRight: "⌘D",
-        ToolbarID.splitDown: "⇧⌘D",
+    private struct ToolbarItemDef {
+        let id: NSToolbarItem.Identifier
+        let label: String
+        let toolTip: String
+        let symbol: String
+        let hint: String
+        let callback: KeyPath<MainWindowController, (() -> Void)?>
+    }
+
+    private static let toolbarItemDefs: [ToolbarItemDef] = [
+        ToolbarItemDef(id: ToolbarID.toggleSidebar, label: .localized("Toggle Sidebar"),
+                       toolTip: .localized("Show or hide the sidebar (⌘B)"),
+                       symbol: "sidebar.left", hint: "⌘B", callback: \.onToggleSidebar),
+        ToolbarItemDef(id: ToolbarID.files, label: .localized("Files"),
+                       toolTip: .localized("Open Files Companion Pane (⌘E)"),
+                       symbol: "folder", hint: "⌘E", callback: \.onToggleFiles),
+        ToolbarItemDef(id: ToolbarID.git, label: .localized("Git"),
+                       toolTip: .localized("Open Git Companion Pane (⌘G)"),
+                       symbol: "point.topleft.down.curvedto.point.bottomright.up", hint: "⌘G", callback: \.onToggleGit),
+        ToolbarItemDef(id: ToolbarID.splitRight, label: .localized("Split Right"),
+                       toolTip: .localized("Split the current pane to the right (⌘D)"),
+                       symbol: "rectangle.split.2x1", hint: "⌘D", callback: \.onSplitRight),
+        ToolbarItemDef(id: ToolbarID.splitDown, label: .localized("Split Down"),
+                       toolTip: .localized("Split the current pane downward (⇧⌘D)"),
+                       symbol: "rectangle.split.1x2", hint: "⇧⌘D", callback: \.onSplitDown),
     ]
 
     var onToggleSidebar: (() -> Void)?
@@ -42,8 +60,6 @@ final class MainWindowController: NSWindowController {
     private let shortcutHintMonitor = ShortcutHintModifierMonitor()
     private var shortcutHintCancellable: AnyCancellable?
     private var shortcutHintOverlays: [NSView] = []
-
-    /// Retained references to toolbar button views keyed by item identifier.
     private var toolbarButtonViews: [NSToolbarItem.Identifier: NSView] = [:]
 
     // MARK: - Init
@@ -89,20 +105,15 @@ final class MainWindowController: NSWindowController {
 
     func saveFrame() {
         guard let window else { return }
-        let frameString = NSStringFromRect(window.frame)
-        UserDefaults.standard.set(frameString, forKey: Self.frameKey)
+        UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameKey)
     }
 
-    /// Show the worktree creation panel. Delegates to the callback wired by AppDelegate.
     func showCreateWorktreePanel() {
         onShowCreateWorktreePanel?()
     }
 
-    /// Adds the update pill as an overlay pinned to the top-right of the titlebar area.
     func addUpdateAccessory(viewModel: UpdateViewModel) {
         guard let window else { return }
-
-        // Find the titlebar container (themeFrame) to overlay onto
         guard let themeFrame = window.contentView?.superview else { return }
 
         let hostingView = NSHostingView(rootView: UpdatePill(model: viewModel))
@@ -138,49 +149,30 @@ final class MainWindowController: NSWindowController {
 
     private static let symbolConfig = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
 
-    private func makeToolbarItem(
-        id: NSToolbarItem.Identifier,
-        label: String,
-        toolTip: String,
-        systemImageName: String,
-        action: Selector
-    ) -> NSToolbarItem {
-        let item = NSToolbarItem(itemIdentifier: id)
-        item.label = label
-        item.paletteLabel = label
-        item.toolTip = toolTip
+    private func makeToolbarItem(for def: ToolbarItemDef) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: def.id)
+        item.label = def.label
+        item.paletteLabel = def.label
+        item.toolTip = def.toolTip
 
-        let image = NSImage(systemSymbolName: systemImageName, accessibilityDescription: label)?
+        let image = NSImage(systemSymbolName: def.symbol, accessibilityDescription: def.label)?
             .withSymbolConfiguration(Self.symbolConfig) ?? NSImage()
 
-        let button = NSButton(image: image, target: self, action: action)
-        button.bezelStyle = .toolbar
-        button.imagePosition = .imageOnly
-        button.setAccessibilityLabel(label)
+        let button = NSButton(image: image, target: self, action: #selector(toolbarAction(_:)))
+        button.bezelStyle = NSButton.BezelStyle.toolbar
+        button.imagePosition = NSControl.ImagePosition.imageOnly
+        button.setAccessibilityLabel(def.label)
+        button.identifier = NSUserInterfaceItemIdentifier(def.id.rawValue)
 
         item.view = button
-        toolbarButtonViews[id] = button
+        toolbarButtonViews[def.id] = button
         return item
     }
 
-    @objc private func toggleSidebarClicked() {
-        onToggleSidebar?()
-    }
-
-    @objc private func toggleFilesClicked() {
-        onToggleFiles?()
-    }
-
-    @objc private func toggleGitClicked() {
-        onToggleGit?()
-    }
-
-    @objc private func splitRightClicked() {
-        onSplitRight?()
-    }
-
-    @objc private func splitDownClicked() {
-        onSplitDown?()
+    @objc private func toolbarAction(_ sender: NSButton) {
+        guard let senderId = sender.identifier?.rawValue,
+              let def = Self.toolbarItemDefs.first(where: { $0.id.rawValue == senderId }) else { return }
+        self[keyPath: def.callback]?()
     }
 
     // MARK: - Shortcut Hint Overlays
@@ -204,32 +196,28 @@ final class MainWindowController: NSWindowController {
         guard let themeFrame = window?.contentView?.superview else { return }
         themeFrame.layoutSubtreeIfNeeded()
 
-        for (id, hint) in Self.toolbarShortcutHints {
-            guard let anchor = toolbarButtonViews[id], anchor.window != nil else { continue }
+        for def in Self.toolbarItemDefs {
+            guard let anchor = toolbarButtonViews[def.id], anchor.window != nil else { continue }
 
-            // Convert button rect to themeFrame coords (bottom-left origin).
             let anchorRect = anchor.convert(anchor.bounds, to: themeFrame)
-
-            let pill = NSHostingView(rootView: ShortcutHintPill(hint))
+            let pill = NSHostingView(rootView: ShortcutHintPill(def.hint))
             let pillSize = pill.fittingSize
 
-            // Center horizontally on the button, position above it (y increases upward).
             pill.frame = NSRect(
                 x: anchorRect.midX - pillSize.width / 2,
                 y: anchorRect.maxY + 2,
                 width: pillSize.width,
                 height: pillSize.height
             )
-            themeFrame.addSubview(pill)
-
             pill.alphaValue = 0
+            themeFrame.addSubview(pill)
             shortcutHintOverlays.append(pill)
         }
 
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.14
             ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-            for overlay in shortcutHintOverlays {
+            for overlay in self.shortcutHintOverlays {
                 overlay.animator().alphaValue = 1
             }
         }
@@ -280,26 +268,21 @@ extension MainWindowController: NSWindowDelegate {
 
 extension MainWindowController: NSToolbarDelegate {
 
+    private static let defaultItemIds: [NSToolbarItem.Identifier] = [
+        ToolbarID.toggleSidebar,
+        .flexibleSpace,
+        ToolbarID.files,
+        ToolbarID.git,
+        ToolbarID.splitRight,
+        ToolbarID.splitDown,
+    ]
+
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [
-            ToolbarID.toggleSidebar,
-            .flexibleSpace,
-            ToolbarID.files,
-            ToolbarID.git,
-            ToolbarID.splitRight,
-            ToolbarID.splitDown,
-        ]
+        Self.defaultItemIds
     }
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [
-            ToolbarID.toggleSidebar,
-            ToolbarID.files,
-            ToolbarID.git,
-            ToolbarID.splitRight,
-            ToolbarID.splitDown,
-            .flexibleSpace,
-        ]
+        Self.defaultItemIds
     }
 
     func toolbar(
@@ -307,49 +290,9 @@ extension MainWindowController: NSToolbarDelegate {
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
-        switch itemIdentifier {
-        case ToolbarID.toggleSidebar:
-            return makeToolbarItem(
-                id: ToolbarID.toggleSidebar,
-                label: .localized("Toggle Sidebar"),
-                toolTip: .localized("Show or hide the sidebar (⌘B)"),
-                systemImageName: "sidebar.left",
-                action: #selector(toggleSidebarClicked)
-            )
-        case ToolbarID.files:
-            return makeToolbarItem(
-                id: ToolbarID.files,
-                label: .localized("Files"),
-                toolTip: .localized("Open Files Companion Pane (⌘E)"),
-                systemImageName: "folder",
-                action: #selector(toggleFilesClicked)
-            )
-        case ToolbarID.git:
-            return makeToolbarItem(
-                id: ToolbarID.git,
-                label: .localized("Git"),
-                toolTip: .localized("Open Git Companion Pane (⌘G)"),
-                systemImageName: "point.topleft.down.curvedto.point.bottomright.up",
-                action: #selector(toggleGitClicked)
-            )
-        case ToolbarID.splitRight:
-            return makeToolbarItem(
-                id: ToolbarID.splitRight,
-                label: .localized("Split Right"),
-                toolTip: .localized("Split the current pane to the right (⌘D)"),
-                systemImageName: "rectangle.split.2x1",
-                action: #selector(splitRightClicked)
-            )
-        case ToolbarID.splitDown:
-            return makeToolbarItem(
-                id: ToolbarID.splitDown,
-                label: .localized("Split Down"),
-                toolTip: .localized("Split the current pane downward (⇧⌘D)"),
-                systemImageName: "rectangle.split.1x2",
-                action: #selector(splitDownClicked)
-            )
-        default:
+        guard let def = Self.toolbarItemDefs.first(where: { $0.id == itemIdentifier }) else {
             return nil
         }
+        return makeToolbarItem(for: def)
     }
 }

--- a/Sources/Mori/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/en.lproj/Localizable.strings
@@ -66,7 +66,9 @@
 "Open Files Companion Pane (⌘E)" = "Open Files Companion Pane (⌘E)";
 "Open Git Companion Pane (⌘G)" = "Open Git Companion Pane (⌘G)";
 "Split the current pane to the right" = "Split the current pane to the right";
+"Split the current pane to the right (⌘D)" = "Split the current pane to the right (⌘D)";
 "Split the current pane downward" = "Split the current pane downward";
+"Split the current pane downward (⇧⌘D)" = "Split the current pane downward (⇧⌘D)";
 "Open Lazygit" = "Open Lazygit";
 "Open Project" = "Open Project";
 "Open Project…" = "Open Project…";
@@ -104,7 +106,7 @@
 "Settings" = "Settings";
 "Settings…" = "Settings…";
 "Show All" = "Show All";
-"Show or hide the sidebar (⌘0)" = "Show or hide the sidebar (⌘0)";
+"Show or hide the sidebar (⌘B)" = "Show or hide the sidebar (⌘B)";
 "Split Down" = "Split Down";
 "Split Right" = "Split Right";
 "Template:" = "Template:";

--- a/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Mori/Resources/zh-Hans.lproj/Localizable.strings
@@ -66,7 +66,9 @@
 "Open Files Companion Pane (⌘E)" = "打开文件工具面板 (⌘E)";
 "Open Git Companion Pane (⌘G)" = "打开 Git 工具面板 (⌘G)";
 "Split the current pane to the right" = "向右拆分当前窗格";
+"Split the current pane to the right (⌘D)" = "向右拆分当前窗格 (⌘D)";
 "Split the current pane downward" = "向下拆分当前窗格";
+"Split the current pane downward (⇧⌘D)" = "向下拆分当前窗格 (⇧⌘D)";
 "Open Lazygit" = "打开 Lazygit";
 "Open Project" = "打开项目";
 "Open Project..." = "打开项目...";
@@ -104,7 +106,7 @@
 "Settings" = "设置";
 "Settings..." = "设置...";
 "Show All" = "全部显示";
-"Show or hide the sidebar (⌘0)" = "显示或隐藏侧栏(⌘0)";
+"Show or hide the sidebar (⌘B)" = "显示或隐藏侧栏 (⌘B)";
 "Split Down" = "向下拆分";
 "Split Right" = "向右拆分";
 "Template:" = "模板:";


### PR DESCRIPTION
## Summary

Add shortcut hint pills to toolbar buttons and sidebar footer when long-pressing ⌘, matching the existing sidebar row hint behavior.

### Toolbar
- All 5 toolbar buttons (Toggle Sidebar, Files, Git, Split Right, Split Down) show shortcut pills on Cmd hold
- Custom `NSButton` views via `item.view` for reliable view ownership
- Pills overlaid on `themeFrame` using frame-based coordinate conversion
- Data-driven `ToolbarItemDef` array replaces repetitive switch/action boilerplate

### Sidebar Footer
- Added `⇧⌘O` shortcut hint to the Open Project button
- Unified button label from "Add Repository" to "Open Project" (same underlying action)

### Fixes
- Fixed sidebar tooltip from incorrect `⌘0` to actual default `⌘B`
- Added shortcut hints to split button tooltips (`⌘D`, `⇧⌘D`)
- Unified all toolbar icon sizes to consistent 13pt
- Updated en + zh-Hans localization strings