### PR TITLE
✨ feat: drag-to-reorder projects in sidebar

### DIFF
--- a/Packages/MoriPersistence/Sources/MoriPersistence/Repositories/ProjectRepository.swift
+++ b/Packages/MoriPersistence/Sources/MoriPersistence/Repositories/ProjectRepository.swift
@@ -35,4 +35,13 @@ public struct ProjectRepository: Sendable {
             data.projects.removeAll { $0.project.id == id }
         }
     }
+
+    public func reorder(ids: [UUID]) throws {
+        store.mutate { data in
+            let lookup = Dictionary(uniqueKeysWithValues: data.projects.map { ($0.project.id, $0) })
+            let reordered = ids.compactMap { lookup[$0] }
+            let remaining = data.projects.filter { !ids.contains($0.project.id) }
+            data.projects = reordered + remaining
+        }
+    }
 }

--- a/Packages/MoriUI/Sources/MoriUI/SidebarContainerView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/SidebarContainerView.swift
@@ -29,6 +29,7 @@ public struct SidebarContainerView: View {
     private let onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)?
     private let onSendKeys: ((String, String) -> Void)?
     private let onUpdateProject: ((Project) -> Void)?
+    private let onReorderProjects: (([UUID]) -> Void)?
 
     public init(
         projects: [Project] = [],
@@ -51,7 +52,8 @@ public struct SidebarContainerView: View {
         onOpenCommandPalette: (() -> Void)? = nil,
         onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)? = nil,
         onSendKeys: ((String, String) -> Void)? = nil,
-        onUpdateProject: ((Project) -> Void)? = nil
+        onUpdateProject: ((Project) -> Void)? = nil,
+        onReorderProjects: (([UUID]) -> Void)? = nil
     ) {
         self.projects = projects
         self.selectedProjectId = selectedProjectId
@@ -74,6 +76,7 @@ public struct SidebarContainerView: View {
         self.onRequestPaneOutput = onRequestPaneOutput
         self.onSendKeys = onSendKeys
         self.onUpdateProject = onUpdateProject
+        self.onReorderProjects = onReorderProjects
     }
 
     /// Shared Cmd-hold shortcut hint monitor — one instance for the entire sidebar.
@@ -102,7 +105,8 @@ public struct SidebarContainerView: View {
             onOpenCommandPalette: onOpenCommandPalette,
             onRequestPaneOutput: onRequestPaneOutput,
             onSendKeys: onSendKeys,
-            onUpdateProject: onUpdateProject
+            onUpdateProject: onUpdateProject,
+            onReorderProjects: onReorderProjects
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {

--- a/Packages/MoriUI/Sources/MoriUI/WorktreeSidebarView.swift
+++ b/Packages/MoriUI/Sources/MoriUI/WorktreeSidebarView.swift
@@ -25,6 +25,7 @@ public struct WorktreeSidebarView: View {
     private let onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)?
     private let onSendKeys: ((String, String) -> Void)?
     private let onUpdateProject: ((Project) -> Void)?
+    private let onReorderProjects: (([UUID]) -> Void)?
     private let shortcutHintsVisible: Bool
 
     public init(
@@ -49,7 +50,8 @@ public struct WorktreeSidebarView: View {
         onOpenCommandPalette: (() -> Void)? = nil,
         onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)? = nil,
         onSendKeys: ((String, String) -> Void)? = nil,
-        onUpdateProject: ((Project) -> Void)? = nil
+        onUpdateProject: ((Project) -> Void)? = nil,
+        onReorderProjects: (([UUID]) -> Void)? = nil
     ) {
         self.projects = projects
         self.selectedProjectId = selectedProjectId
@@ -72,6 +74,7 @@ public struct WorktreeSidebarView: View {
         self.onRequestPaneOutput = onRequestPaneOutput
         self.onSendKeys = onSendKeys
         self.onUpdateProject = onUpdateProject
+        self.onReorderProjects = onReorderProjects
         self.shortcutHintsVisible = shortcutHintsVisible
     }
 
@@ -197,6 +200,8 @@ public struct WorktreeSidebarView: View {
     @State private var hoveredProjectId: UUID?
     @State private var renamingProjectId: UUID?
     @State private var renameText: String = ""
+    @State private var draggingProjectId: UUID?
+    @State private var dropTargetProjectId: UUID?
 
     @ViewBuilder
     private func projectSection(_ project: Project) -> some View {
@@ -239,7 +244,45 @@ public struct WorktreeSidebarView: View {
         .padding(.top, 14)
         .padding(.bottom, MoriTokens.Spacing.sm)
         .contentShape(Rectangle())
+        .overlay(alignment: .top) {
+            if dropTargetProjectId == project.id && draggingProjectId != project.id {
+                Rectangle()
+                    .fill(MoriTokens.Color.active)
+                    .frame(height: 2)
+                    .padding(.horizontal, MoriTokens.Spacing.xl)
+            }
+        }
         .animation(.easeInOut(duration: 0.14), value: shortcutHintsVisible)
+        .draggable(project.id.uuidString) {
+            Text(project.name)
+                .font(MoriTokens.Font.projectTitle)
+                .padding(.horizontal, MoriTokens.Spacing.lg)
+                .padding(.vertical, MoriTokens.Spacing.sm)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: MoriTokens.Radius.small))
+        }
+        .dropDestination(for: String.self) { items, _ in
+            guard let draggedIdStr = items.first,
+                  let draggedId = UUID(uuidString: draggedIdStr),
+                  draggedId != project.id else {
+                dropTargetProjectId = nil
+                return false
+            }
+            var ids = projects.map { $0.id }
+            guard let fromIdx = ids.firstIndex(of: draggedId),
+                  let toIdx = ids.firstIndex(of: project.id) else {
+                dropTargetProjectId = nil
+                return false
+            }
+            ids.remove(at: fromIdx)
+            ids.insert(draggedId, at: toIdx)
+            onReorderProjects?(ids)
+            dropTargetProjectId = nil
+            draggingProjectId = nil
+            return true
+        } isTargeted: { targeted in
+            dropTargetProjectId = targeted ? project.id : nil
+        }
         .onTapGesture {
             onToggleCollapse?(project.id)
             onSelectProject?(project.id)

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -216,6 +216,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             },
             onUpdateProject: { [weak manager] project in
                 manager?.updateProject(project)
+            },
+            onReorderProjects: { [weak manager] orderedIds in
+                manager?.reorderProjects(orderedIds)
             }
         )
 

--- a/Sources/Mori/App/HostingControllers.swift
+++ b/Sources/Mori/App/HostingControllers.swift
@@ -28,7 +28,8 @@ final class SidebarHostingController: NSHostingController<SidebarContentView> {
         onOpenCommandPalette: (() -> Void)? = nil,
         onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)? = nil,
         onSendKeys: ((String, String) -> Void)? = nil,
-        onUpdateProject: ((Project) -> Void)? = nil
+        onUpdateProject: ((Project) -> Void)? = nil,
+        onReorderProjects: (([UUID]) -> Void)? = nil
     ) {
         self.appState = appState
         let rootView = SidebarContentView(
@@ -47,7 +48,8 @@ final class SidebarHostingController: NSHostingController<SidebarContentView> {
             onOpenCommandPalette: onOpenCommandPalette,
             onRequestPaneOutput: onRequestPaneOutput,
             onSendKeys: onSendKeys,
-            onUpdateProject: onUpdateProject
+            onUpdateProject: onUpdateProject,
+            onReorderProjects: onReorderProjects
         )
         super.init(rootView: rootView)
         // Prevent SwiftUI's layout from dictating the view size.
@@ -90,6 +92,7 @@ struct SidebarContentView: View {
     let onRequestPaneOutput: ((String, @escaping (String?) -> Void) -> Void)?
     let onSendKeys: ((String, String) -> Void)?
     let onUpdateProject: ((Project) -> Void)?
+    let onReorderProjects: (([UUID]) -> Void)?
 
     var body: some View {
         SidebarContainerView(
@@ -113,7 +116,8 @@ struct SidebarContentView: View {
             onOpenCommandPalette: onOpenCommandPalette,
             onRequestPaneOutput: onRequestPaneOutput,
             onSendKeys: onSendKeys,
-            onUpdateProject: onUpdateProject
+            onUpdateProject: onUpdateProject,
+            onReorderProjects: onReorderProjects
         )
     }
 }

--- a/Sources/Mori/App/WorkspaceManager.swift
+++ b/Sources/Mori/App/WorkspaceManager.swift
@@ -563,6 +563,13 @@ final class WorkspaceManager {
         try? projectRepo.save(project)
     }
 
+    /// Reorder projects to match the given ID sequence and persist.
+    func reorderProjects(_ orderedIds: [UUID]) {
+        let lookup = Dictionary(uniqueKeysWithValues: appState.projects.map { ($0.id, $0) })
+        appState.projects = orderedIds.compactMap { lookup[$0] }
+        try? projectRepo.reorder(ids: orderedIds)
+    }
+
     // MARK: - Add Project
 
     /// Add a new project from a directory path. Creates Project, default Worktree,


### PR DESCRIPTION
## Summary

Adds drag-and-drop reordering for projects in the sidebar.

## Changes

- **`ProjectRepository`**: Added `reorder(ids:)` to persist a new project ordering atomically.
- **`WorkspaceManager`**: Added `reorderProjects(_ orderedIds:)` to update in-memory state and persist.
- **`WorktreeSidebarView`**: Project section headers are now draggable. Dropping on another project inserts it before the target and fires `onReorderProjects`. A blue 2pt line indicates the drop target.
- Wired `onReorderProjects` through `SidebarContainerView` → `SidebarHostingController` / `SidebarContentView` → `AppDelegate`.