### PR TITLE
fix: apply tmux status off to newly created sessions

### DIFF
--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -301,7 +301,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             // Apply theme (including status bar off) to the newly created session
             if let self {
-                self.scheduleTmuxThemeApply(immediate: true, tmuxBackend: tmuxBackend)
+                self.scheduleTmuxThemeApply(immediate: true, force: true, tmuxBackend: tmuxBackend)
             }
         }
 
@@ -867,7 +867,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func scheduleTmuxThemeApply(immediate: Bool, tmuxBackend: TmuxBackend) {
+    private func scheduleTmuxThemeApply(immediate: Bool, force: Bool = false, tmuxBackend: TmuxBackend) {
         tmuxThemeApplyTask?.cancel()
         let delayNanoseconds = immediate ? 0 : tmuxThemeDebounceNanoseconds
         tmuxThemeApplyTask = Task { [weak self] in
@@ -876,7 +876,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             guard !Task.isCancelled,
                   let themeInfo = self?.terminalAreaController?.themeInfo else { return }
-            await TmuxThemeApplicator.apply(themeInfo: themeInfo, tmuxBackend: tmuxBackend)
+            await TmuxThemeApplicator.apply(themeInfo: themeInfo, tmuxBackend: tmuxBackend, force: force)
         }
     }
 

--- a/Sources/Mori/App/TmuxThemeApplicator.swift
+++ b/Sources/Mori/App/TmuxThemeApplicator.swift
@@ -33,10 +33,12 @@ enum TmuxThemeApplicator {
 
     private static let cache = Cache()
 
-    static func apply(themeInfo: GhosttyThemeInfo, tmuxBackend: TmuxBackend) async {
+    static func apply(themeInfo: GhosttyThemeInfo, tmuxBackend: TmuxBackend, force: Bool = false) async {
         let payload = makePayload(themeInfo: themeInfo)
         let backendID = ObjectIdentifier(tmuxBackend)
-        guard await cache.shouldApply(payload, backendID: backendID) else { return }
+        if !force {
+            guard await cache.shouldApply(payload, backendID: backendID) else { return }
+        }
 
         let styles = makeStyles(payload: payload)
         await applyGlobalCompatibilityOptions(tmuxBackend: tmuxBackend)


### PR DESCRIPTION
## Problem

When adding a new project, the tmux status line remains visible even though Mori should hide it.

## Root Cause

`TmuxThemeApplicator` caches the theme payload per backend. When a new session is created and the theme hasn't changed, the cache causes an early return - skipping the `status off` option for the new session.

## Solution

Added a `force` parameter to `TmuxThemeApplicator.apply()` that bypasses the cache. The `onSessionCreated` callback now uses `force: true` to ensure theme options are applied to newly created sessions.

## Changes

- `TmuxThemeApplicator.swift`: Added `force: Bool = false` parameter
- `AppDelegate.swift`: Pass `force: true` when applying theme after session creation