### PR TITLE
🐛 fix: preserve symlinked agent settings on hook install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Bug Fixes
 
 - Include system fonts like JetBrains Maple Mono in the terminal font picker even when AppKit does not flag them as fixed-pitch, by falling back to uniform glyph-width detection
+- Preserve symlinked agent settings files (e.g. `~/.claude/settings.json` linked into a dotfiles repo) when installing hooks; the atomic write now resolves the symlink first so the link is no longer replaced with a regular file ([#80](https://github.com/vaayne/mori/issues/80))
 
 ## [0.4.0] - 2026-04-18
 

--- a/CHANGELOG.zh-Hans.md
+++ b/CHANGELOG.zh-Hans.md
@@ -14,6 +14,7 @@
 ### 🐛 问题修复
 
 - 终端字体选择器现在会包含 JetBrains Maple Mono 这类系统字体：当 AppKit 没有将其标记为等宽字体时，改为回退到统一字形宽度检测来识别
+- 安装 Agent Hook 时保留软链接的 agent 配置文件（例如指向 dotfiles 仓库的 `~/.claude/settings.json`）：原子写入现在会先解析软链接目标，避免链接被替换为普通文件 ([#80](https://github.com/vaayne/mori/issues/80))
 
 ## [0.4.0] - 2026-04-18
 

--- a/Sources/Mori/App/AgentHookConfigurator.swift
+++ b/Sources/Mori/App/AgentHookConfigurator.swift
@@ -459,7 +459,11 @@ enum AgentHookConfigurator {
         guard let data = try? JSONSerialization.data(
             withJSONObject: object, options: [.prettyPrinted, .sortedKeys]
         ) else { return }
-        try? data.write(to: url, options: .atomic)
+        // `.atomic` uses rename(), which replaces a symlink target with a
+        // regular file instead of following it. Resolve first so users whose
+        // settings.json is a symlink into a dotfiles repo keep the link intact.
+        let resolved = url.resolvingSymlinksInPath()
+        try? data.write(to: resolved, options: .atomic)
     }
 
     /// Parse a TOML string array like `notify = ["/a", "/b"]` into `["/a", "/b"]`.


### PR DESCRIPTION
## Summary

Fixes #80 — installing agent hooks silently destroyed `~/.claude/settings.json` when it was a symlink into a dotfiles repo.

`Data.write(to:options:.atomic)` writes to a temp file then `rename()`s it into place. `rename()` replaces a symlink target with a regular file instead of following it, so the first hook install blew away the symlink and left the dotfiles source stale.

Fix is a one-line change in `AgentHookConfigurator.writeJSON`: resolve the path first so `.atomic` still gives crash safety, but the rename happens at the real target and the symlink at the original location stays intact.

`resolvingSymlinksInPath()` passes non-existent components through unchanged, so first-time installs (no file yet) still work.

## Test plan

- [x] `swift build --product Mori` — clean
- [ ] Manual: symlink `~/.claude/settings.json` to a dotfiles file, run Mori hook install, verify the symlink is preserved and the dotfiles file was updated
- [ ] Manual: fresh machine with no `~/.claude/settings.json`, verify hook install still creates the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)