### PR TITLE
🐛 fix: close companion pane immediately when Lazygit/Yazi exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include system fonts like JetBrains Maple Mono in the terminal font picker even when AppKit does not flag them as fixed-pitch, by falling back to uniform glyph-width detection
 - Preserve symlinked agent settings files (e.g. `~/.claude/settings.json` linked into a dotfiles repo) when installing hooks; the atomic write now resolves the symlink first so the link is no longer replaced with a regular file ([#80](https://github.com/vaayne/mori/issues/80))
+- Automatically close the companion Git / Files pane when the embedded Lazygit or Yazi process exits, instead of leaving a blank panel that could not be dismissed without restarting Mori ([#79](https://github.com/vaayne/mori/issues/79))
 
 ## [0.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include system fonts like JetBrains Maple Mono in the terminal font picker even when AppKit does not flag them as fixed-pitch, by falling back to uniform glyph-width detection
 - Preserve symlinked agent settings files (e.g. `~/.claude/settings.json` linked into a dotfiles repo) when installing hooks; the atomic write now resolves the symlink first so the link is no longer replaced with a regular file ([#80](https://github.com/vaayne/mori/issues/80))
-- Automatically close the companion Git / Files pane when the embedded Lazygit or Yazi process exits, instead of leaving a blank panel that could not be dismissed without restarting Mori ([#79](https://github.com/vaayne/mori/issues/79))
+- Automatically close the companion Git / Files pane when the embedded Lazygit or Yazi process exits — no longer leaves a blank "press any key to close" panel that could only be dismissed by restarting Mori ([#79](https://github.com/vaayne/mori/issues/79))
 
 ## [0.4.0] - 2026-04-18
 

--- a/CHANGELOG.zh-Hans.md
+++ b/CHANGELOG.zh-Hans.md
@@ -15,7 +15,7 @@
 
 - 终端字体选择器现在会包含 JetBrains Maple Mono 这类系统字体：当 AppKit 没有将其标记为等宽字体时，改为回退到统一字形宽度检测来识别
 - 安装 Agent Hook 时保留软链接的 agent 配置文件（例如指向 dotfiles 仓库的 `~/.claude/settings.json`）：原子写入现在会先解析软链接目标，避免链接被替换为普通文件 ([#80](https://github.com/vaayne/mori/issues/80))
-- Lazygit / Yazi 等嵌入工具进程退出后，右侧 Git / Files 面板会自动关闭，不再残留一个无法关闭的空白面板，也不再需要重启 Mori 才能恢复 ([#79](https://github.com/vaayne/mori/issues/79))
+- Lazygit / Yazi 等嵌入工具进程退出后，右侧 Git / Files 面板会立即自动关闭，不再残留一个提示 "press any key to close" 且只能通过重启 Mori 才能关闭的空白面板 ([#79](https://github.com/vaayne/mori/issues/79))
 
 ## [0.4.0] - 2026-04-18
 

--- a/CHANGELOG.zh-Hans.md
+++ b/CHANGELOG.zh-Hans.md
@@ -15,6 +15,7 @@
 
 - 终端字体选择器现在会包含 JetBrains Maple Mono 这类系统字体：当 AppKit 没有将其标记为等宽字体时，改为回退到统一字形宽度检测来识别
 - 安装 Agent Hook 时保留软链接的 agent 配置文件（例如指向 dotfiles 仓库的 `~/.claude/settings.json`）：原子写入现在会先解析软链接目标，避免链接被替换为普通文件 ([#80](https://github.com/vaayne/mori/issues/80))
+- Lazygit / Yazi 等嵌入工具进程退出后，右侧 Git / Files 面板会自动关闭，不再残留一个无法关闭的空白面板，也不再需要重启 Mori 才能恢复 ([#79](https://github.com/vaayne/mori/issues/79))
 
 ## [0.4.0] - 2026-04-18
 

--- a/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyApp.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/GhosttyApp.swift
@@ -267,6 +267,29 @@ final class GhosttyApp {
             moriAction = .openConfig
         case GHOSTTY_ACTION_TOGGLE_FULLSCREEN:
             moriAction = .toggleFullscreen
+        case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
+            // Ghostty's embedded API forces wait-after-command=true whenever a
+            // command is passed, so on normal child exit it would print
+            // "Process exited. Press any key to close." and wait. We intercept
+            // the native show_child_exited action here, forward a close signal
+            // via NotificationCenter so Mori tears the surface down immediately,
+            // and return true to suppress ghostty's fallback terminal message.
+            if target.tag == GHOSTTY_TARGET_SURFACE,
+               let surface = target.target.surface,
+               let rawUserdata = ghostty_surface_userdata(surface) {
+                let userdataInt = UInt(bitPattern: rawUserdata)
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(
+                        name: .ghosttySurfaceDidClose,
+                        object: nil,
+                        userInfo: [
+                            "userdata": userdataInt,
+                            "processAlive": false,
+                        ]
+                    )
+                }
+            }
+            return true
         default:
             return false
         }

--- a/Packages/MoriTerminal/Sources/MoriTerminal/TerminalSurfaceCache.swift
+++ b/Packages/MoriTerminal/Sources/MoriTerminal/TerminalSurfaceCache.swift
@@ -69,6 +69,22 @@ public final class TerminalSurfaceCache {
         terminalHost.destroySurface(entry.surface)
     }
 
+    /// Remove a cached surface whose view pointer matches the given userdata.
+    /// Used when a ghostty surface signals exit: the notification carries the
+    /// view's opaque pointer, which may correspond to a cached surface that
+    /// is not currently attached to any view controller.
+    @discardableResult
+    public func removeByUserdata(_ userdata: UInt) -> Bool {
+        for (key, entry) in entries {
+            let entryUserdata = UInt(bitPattern: Unmanaged.passUnretained(entry.surface).toOpaque())
+            if entryUserdata == userdata {
+                remove(sessionKey: key)
+                return true
+            }
+        }
+        return false
+    }
+
     /// Remove all cached surfaces.
     public func removeAll() {
         for entry in entries.values {

--- a/Sources/Mori/App/AppDelegate.swift
+++ b/Sources/Mori/App/AppDelegate.swift
@@ -101,6 +101,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let companionTool = CompanionToolPaneController()
         self.companionToolController = companionTool
+        companionTool.onToolExited = { [weak self] in
+            guard let self else { return }
+            self.closeCompanionTool()
+            self.terminalAreaController?.focusCurrentSurface()
+        }
 
         // Wire ghostty keybinding actions to Mori's tmux-based implementation.
         // Ghostty maps keys to intents (new_tab, close_tab, etc.); Mori provides

--- a/Sources/Mori/App/CompanionToolPaneController.swift
+++ b/Sources/Mori/App/CompanionToolPaneController.swift
@@ -59,9 +59,18 @@ final class CompanionToolPaneController: NSViewController {
 
     private(set) var activeTool: CompanionTool?
 
+    /// Invoked when the embedded tool's process exits (e.g., user presses `q` in lazygit).
+    /// The owner should close the companion pane in response.
+    var onToolExited: (() -> Void)?
+
     init(terminalHost: TerminalHost? = nil) {
         self.terminalController = TerminalAreaViewController(terminalHost: terminalHost)
         super.init(nibName: nil, bundle: nil)
+        terminalController.onSurfaceExited = { [weak self] in
+            guard let self else { return }
+            self.activeTool = nil
+            self.onToolExited?()
+        }
     }
 
     @available(*, unavailable)

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -98,6 +98,11 @@ final class TerminalAreaViewController: NSViewController {
     /// Whether the empty state should show "Reconnect" (dead session) vs "Add Project" (no project).
     var hasSelectedWorktree: Bool = false
 
+    /// Invoked when the current surface exits. When set, the controller forwards
+    /// control to the owner instead of showing the empty state / auto-reconnecting —
+    /// used by ephemeral companion tools (lazygit, yazi) that close on process exit.
+    var onSurfaceExited: (() -> Void)?
+
     // MARK: - Init
 
     init(terminalHost: TerminalHost? = nil) {
@@ -536,6 +541,12 @@ final class TerminalAreaViewController: NSViewController {
         self.currentSurface = nil
         self.currentSessionKey = nil
         removeResidualTerminalSubviews()
+
+        if let onSurfaceExited {
+            onSurfaceExited()
+            return
+        }
+
         isAutoReconnecting = true
         showEmptyState()
 

--- a/Sources/Mori/App/TerminalAreaViewController.swift
+++ b/Sources/Mori/App/TerminalAreaViewController.swift
@@ -523,16 +523,31 @@ final class TerminalAreaViewController: NSViewController {
     private func handleSurfaceClosed(_ notification: Notification) {
         guard !isHandlingSurfaceExit else { return }
         guard let userInfo = notification.userInfo,
-              let userdata = userInfo["userdata"] as? UInt,
-              let currentSurface else { return }
+              let userdata = userInfo["userdata"] as? UInt else { return }
 
-        let currentUserdata = UInt(bitPattern: Unmanaged.passUnretained(currentSurface).toOpaque())
-        guard userdata == currentUserdata else { return }
+        // Fan-out: this notification is delivered to every TerminalAreaViewController
+        // (e.g., the main terminal + companion pane). Each instance checks its own
+        // currentSurface and cache; exactly one owns the exited surface, others no-op.
+        if let currentSurface {
+            let currentUserdata = UInt(bitPattern: Unmanaged.passUnretained(currentSurface).toOpaque())
+            if userdata == currentUserdata {
+                handleCurrentSurfaceExit()
+                return
+            }
+        }
 
+        // Surface isn't currently attached but may still live in this cache (e.g.,
+        // user switched away from a lazygit companion that then quit in the background).
+        // Evict so the next attach creates a fresh process instead of binding to a
+        // dead surface that ghostty has already torn down.
+        surfaceCache.removeByUserdata(userdata)
+    }
+
+    private func handleCurrentSurfaceExit() {
         isHandlingSurfaceExit = true
         defer { isHandlingSurfaceExit = false }
 
-        currentSurface.removeFromSuperview()
+        currentSurface?.removeFromSuperview()
 
         // Remove dead surface from cache so reconnect creates a fresh process.
         if let sessionKey = currentSessionKey {


### PR DESCRIPTION
## Summary

Fixes #79. The right-side Git / Files pane now closes immediately when the embedded tool exits, instead of leaving a blank panel that could only be dismissed by restarting Mori.

- Intercept `GHOSTTY_ACTION_SHOW_CHILD_EXITED` in Mori's action callback — returning `true` suppresses ghostty's fallback "Process exited. Press any key to close." message, and we post `.ghosttySurfaceDidClose` ourselves so the surface tears down with no keypress.
- Add an `onSurfaceExited` hook on `TerminalAreaViewController`; `CompanionToolPaneController` wires it to a new `onToolExited` callback that `AppDelegate` uses to collapse the pane and return focus to the main terminal (matches the manual `⌘G` toggle path).
- Preserve the existing empty-state + auto-reconnect behavior for the main terminal — only the companion pane opts into auto-close.

## Root cause

`vendor/ghostty/src/apprt/embedded.zig:533` force-sets `wait-after-command = true` whenever a command is passed to `ghostty_surface_new`, so on child exit ghostty rendered the "press any key" message and blocked. The `close_surface_cb` only fired *after* the keypress — the pane had no signal to close on its own.

## Test plan

- [x] `swift build -c release --product Mori`
- [x] `mise run test` — all packages pass
- [x] Manual: `Tmux → Open Lazygit` → press `q` → pane closes immediately, no keypress required, focus returns to main terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)